### PR TITLE
[🔨 Fix] Notion 이슈번호 속성명 fallback 지원 (#2)

### DIFF
--- a/.github/scripts/notion-sync.mjs
+++ b/.github/scripts/notion-sync.mjs
@@ -36,14 +36,34 @@ const STATUS = {
 const PEOPLE_MAP = parsePeopleMap(process.env.NOTION_PEOPLE_MAP);
 const ISSUE_SYNC_ACTIONS = ['opened', 'edited', 'reopened', 'closed', 'assigned', 'unassigned'];
 const PR_SYNC_ACTIONS = ['opened', 'reopened', 'ready_for_review', 'closed'];
-const ISSUE_NUMBER_PROPERTY_CANDIDATES = [
-  PROPS.issueNumber,
-  'Github 이슈 번호',
-  'GitHub 이슈 번호',
-  '이슈 번호',
-  'Issue Number',
-].filter(Boolean);
 const MAX_TEXT = 1800;
+const RESOLVED_PROP_TYPES = {};
+
+const PROP_ALIASES = {
+  issueNumber: ['Github 이슈 번호', 'GitHub 이슈 번호', '이슈 번호', 'Issue Number'],
+  title: ['제목', 'Name', '이름', 'Title'],
+  status: ['상태', 'Status'],
+  issueUrl: ['이슈 URL', 'Github 이슈', 'GitHub 이슈', 'Github Issue', 'GitHub Issue', 'Issue URL'],
+  prUrl: ['PR URL', 'Github PR', 'GitHub PR', 'Pull Request URL'],
+  summary: ['요약', 'Summary', '설명', 'Description'],
+  assignee: ['담당자', 'Assignee', 'Owner'],
+  assigneeText: ['담당자(텍스트)', '담당자 텍스트', 'Assignee Text'],
+  dueDate: ['마감일', 'Due Date', 'Deadline'],
+};
+
+const PROP_TYPES = {
+  issueNumber: ['number'],
+  title: ['title'],
+  status: ['status', 'select'],
+  issueUrl: ['url'],
+  prUrl: ['url'],
+  summary: ['rich_text'],
+  assignee: ['people'],
+  assigneeText: ['rich_text'],
+  dueDate: ['date'],
+};
+
+const OPTIONAL_PROP_KEYS = new Set(['status', 'issueUrl', 'prUrl', 'summary', 'assignee', 'assigneeText', 'dueDate']);
 
 function normalizeNotionId(rawValue, envName) {
   const value = String(rawValue || '').trim();
@@ -90,6 +110,10 @@ function parsePeopleMap(rawValue) {
     console.warn(`Invalid NOTION_PEOPLE_MAP: ${error.message}`);
     return {};
   }
+}
+
+function normalizePropertyName(value) {
+  return String(value || '').trim().toLowerCase().replace(/\s+/g, '');
 }
 
 function truncate(value, maxLength = MAX_TEXT) {
@@ -186,13 +210,26 @@ function buildAssigneeProperties(assignees) {
     console.log(`Unmapped GitHub assignees: ${unmappedLogins.join(', ')}`);
   }
 
+  const properties = {};
   const uniqueMappedIds = [...new Set(mappedIds)];
-  return {
-    [PROPS.assignee]: {
-      people: uniqueMappedIds.map((id) => ({ id })),
-    },
-    [PROPS.assigneeText]: toRichText(unmappedLogins.join(', ')),
-  };
+
+  if (PROPS.assignee) {
+    properties[PROPS.assignee] = { people: uniqueMappedIds.map((id) => ({ id })) };
+  }
+
+  if (PROPS.assigneeText) {
+    properties[PROPS.assigneeText] = toRichText(unmappedLogins.join(', '));
+  }
+
+  return properties;
+}
+
+function buildStatusValue(statusName) {
+  const propType = RESOLVED_PROP_TYPES.status;
+  if (propType === 'select') {
+    return { select: { name: statusName } };
+  }
+  return { status: { name: statusName } };
 }
 
 async function notionRequest(path, method, body) {
@@ -222,35 +259,54 @@ async function notionRequest(path, method, body) {
   return data;
 }
 
-async function findPageByIssueNumber(issueNumber) {
-  let lastError = null;
+async function resolveNotionPropertyMapping() {
+  const database = await notionRequest(`/databases/${NOTION_DATABASE_ID}`, 'GET');
+  const properties = database?.properties || {};
+  const dbProperties = Object.entries(properties).map(([name, def]) => ({
+    name,
+    type: def?.type,
+  }));
 
-  for (const propertyName of [...new Set(ISSUE_NUMBER_PROPERTY_CANDIDATES)]) {
-    try {
-      const result = await notionRequest(`/databases/${NOTION_DATABASE_ID}/query`, 'POST', {
-        filter: {
-          property: propertyName,
-          number: { equals: issueNumber },
-        },
-        page_size: 1,
-      });
+  for (const [propKey, expectedTypes] of Object.entries(PROP_TYPES)) {
+    const candidates = [PROPS[propKey], ...(PROP_ALIASES[propKey] || [])]
+      .filter((value) => Boolean(value))
+      .map((value) => String(value).trim());
 
-      if (PROPS.issueNumber !== propertyName) {
-        console.log(`Using Notion issue number property: ${propertyName}`);
-        PROPS.issueNumber = propertyName;
+    let found = null;
+    for (const candidate of [...new Set(candidates)]) {
+      found = dbProperties.find((property) =>
+        normalizePropertyName(property.name) === normalizePropertyName(candidate) &&
+        expectedTypes.includes(property.type));
+      if (found) {
+        break;
       }
+    }
 
-      return result.results?.[0] || null;
-    } catch (error) {
-      if (String(error?.message || '').includes('Could not find property with name or id')) {
-        lastError = error;
+    if (!found) {
+      if (OPTIONAL_PROP_KEYS.has(propKey)) {
+        PROPS[propKey] = null;
         continue;
       }
-      throw error;
+      throw new Error(`Cannot resolve required Notion property for "${propKey}". Tried: ${candidates.join(', ')}`);
     }
+
+    PROPS[propKey] = found.name;
+    RESOLVED_PROP_TYPES[propKey] = found.type;
   }
 
-  throw lastError || new Error(`Cannot find issue number property in Notion DB. Tried: ${ISSUE_NUMBER_PROPERTY_CANDIDATES.join(', ')}`);
+  console.log(`Resolved Notion properties: ${JSON.stringify(PROPS)}`);
+}
+
+async function findPageByIssueNumber(issueNumber) {
+  const result = await notionRequest(`/databases/${NOTION_DATABASE_ID}/query`, 'POST', {
+    filter: {
+      property: PROPS.issueNumber,
+      number: { equals: issueNumber },
+    },
+    page_size: 1,
+  });
+
+  return result.results?.[0] || null;
 }
 
 async function createPage(properties) {
@@ -393,25 +449,40 @@ async function handleIssueEvent(payload) {
   const properties = {
     [PROPS.issueNumber]: { number: issue.number },
     [PROPS.title]: toTitle(issue.title),
-    [PROPS.issueUrl]: { url: issue.html_url },
-    [PROPS.summary]: toRichText(buildIssueSummary(issue)),
-    [PROPS.dueDate]: toDate(dueDate),
     ...assigneeProperties,
   };
 
-  if (status) {
-    properties[PROPS.status] = { select: { name: status } };
+  if (PROPS.issueUrl) {
+    properties[PROPS.issueUrl] = { url: issue.html_url };
+  }
+  if (PROPS.summary) {
+    properties[PROPS.summary] = toRichText(buildIssueSummary(issue));
+  }
+  if (PROPS.dueDate) {
+    properties[PROPS.dueDate] = toDate(dueDate);
+  }
+  if (status && PROPS.status) {
+    properties[PROPS.status] = buildStatusValue(status);
   }
 
   const createDefaults = {
     [PROPS.issueNumber]: { number: issue.number },
     [PROPS.title]: toTitle(issue.title),
-    [PROPS.status]: { select: { name: status || STATUS.todo } },
-    [PROPS.issueUrl]: { url: issue.html_url },
-    [PROPS.summary]: toRichText(buildIssueSummary(issue)),
-    [PROPS.dueDate]: toDate(dueDate),
     ...assigneeProperties,
   };
+
+  if (PROPS.status) {
+    createDefaults[PROPS.status] = buildStatusValue(status || STATUS.todo);
+  }
+  if (PROPS.issueUrl) {
+    createDefaults[PROPS.issueUrl] = { url: issue.html_url };
+  }
+  if (PROPS.summary) {
+    createDefaults[PROPS.summary] = toRichText(buildIssueSummary(issue));
+  }
+  if (PROPS.dueDate) {
+    createDefaults[PROPS.dueDate] = toDate(dueDate);
+  }
 
   await upsertByIssueNumber(issue.number, properties, createDefaults);
 }
@@ -439,29 +510,38 @@ async function handlePullRequestEvent(payload) {
   const properties = {
     [PROPS.issueNumber]: { number: issueNumber },
     [PROPS.title]: toTitle(pr.title),
-    [PROPS.prUrl]: { url: pr.html_url },
-    [PROPS.summary]: toRichText(buildPrSummary(pr)),
     ...assigneeProperties,
   };
 
-  if (status) {
-    properties[PROPS.status] = { select: { name: status } };
+  if (PROPS.prUrl) {
+    properties[PROPS.prUrl] = { url: pr.html_url };
   }
-
-  if (issueUrl) {
+  if (PROPS.summary) {
+    properties[PROPS.summary] = toRichText(buildPrSummary(pr));
+  }
+  if (status && PROPS.status) {
+    properties[PROPS.status] = buildStatusValue(status);
+  }
+  if (issueUrl && PROPS.issueUrl) {
     properties[PROPS.issueUrl] = { url: issueUrl };
   }
 
   const createDefaults = {
     [PROPS.issueNumber]: { number: issueNumber },
     [PROPS.title]: toTitle(pr.title),
-    [PROPS.status]: { select: { name: status || STATUS.inProgress } },
-    [PROPS.prUrl]: { url: pr.html_url },
-    [PROPS.summary]: toRichText(buildPrSummary(pr)),
     ...assigneeProperties,
   };
 
-  if (issueUrl) {
+  if (PROPS.status) {
+    createDefaults[PROPS.status] = buildStatusValue(status || STATUS.inProgress);
+  }
+  if (PROPS.prUrl) {
+    createDefaults[PROPS.prUrl] = { url: pr.html_url };
+  }
+  if (PROPS.summary) {
+    createDefaults[PROPS.summary] = toRichText(buildPrSummary(pr));
+  }
+  if (issueUrl && PROPS.issueUrl) {
     createDefaults[PROPS.issueUrl] = { url: issueUrl };
   }
 
@@ -471,6 +551,8 @@ async function handlePullRequestEvent(payload) {
 async function main() {
   const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
   const eventName = process.env.GITHUB_EVENT_NAME;
+
+  await resolveNotionPropertyMapping();
 
   if (eventName === 'issues' && ISSUE_SYNC_ACTIONS.includes(payload.action)) {
     await handleIssueEvent(payload);

--- a/.github/scripts/notion-sync.mjs
+++ b/.github/scripts/notion-sync.mjs
@@ -36,6 +36,13 @@ const STATUS = {
 const PEOPLE_MAP = parsePeopleMap(process.env.NOTION_PEOPLE_MAP);
 const ISSUE_SYNC_ACTIONS = ['opened', 'edited', 'reopened', 'closed', 'assigned', 'unassigned'];
 const PR_SYNC_ACTIONS = ['opened', 'reopened', 'ready_for_review', 'closed'];
+const ISSUE_NUMBER_PROPERTY_CANDIDATES = [
+  PROPS.issueNumber,
+  'Github 이슈 번호',
+  'GitHub 이슈 번호',
+  '이슈 번호',
+  'Issue Number',
+].filter(Boolean);
 const MAX_TEXT = 1800;
 
 function normalizeNotionId(rawValue, envName) {
@@ -216,15 +223,34 @@ async function notionRequest(path, method, body) {
 }
 
 async function findPageByIssueNumber(issueNumber) {
-  const result = await notionRequest(`/databases/${NOTION_DATABASE_ID}/query`, 'POST', {
-    filter: {
-      property: PROPS.issueNumber,
-      number: { equals: issueNumber },
-    },
-    page_size: 1,
-  });
+  let lastError = null;
 
-  return result.results?.[0] || null;
+  for (const propertyName of [...new Set(ISSUE_NUMBER_PROPERTY_CANDIDATES)]) {
+    try {
+      const result = await notionRequest(`/databases/${NOTION_DATABASE_ID}/query`, 'POST', {
+        filter: {
+          property: propertyName,
+          number: { equals: issueNumber },
+        },
+        page_size: 1,
+      });
+
+      if (PROPS.issueNumber !== propertyName) {
+        console.log(`Using Notion issue number property: ${propertyName}`);
+        PROPS.issueNumber = propertyName;
+      }
+
+      return result.results?.[0] || null;
+    } catch (error) {
+      if (String(error?.message || '').includes('Could not find property with name or id')) {
+        lastError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw lastError || new Error(`Cannot find issue number property in Notion DB. Tried: ${ISSUE_NUMBER_PROPERTY_CANDIDATES.join(', ')}`);
 }
 
 async function createPage(properties) {


### PR DESCRIPTION
## 연관 이슈

- Closes #2

## 변경 요약

- Notion DB 조회 시 이슈 번호 속성명을 단일 값으로만 가정하지 않고 fallback 후보를 순차 탐색하도록 수정

## 구현 상세

- `.github/scripts/notion-sync.mjs`
  - 이슈 번호 속성명 후보 목록 추가:
    - `NOTION_PROP_ISSUE_NUMBER`
    - `Github 이슈 번호`
    - `GitHub 이슈 번호`
    - `이슈 번호`
    - `Issue Number`
  - DB query에서 후보를 순차 시도하고, 성공한 속성명을 런타임에 채택
  - 모든 후보 실패 시 명시적 에러 메시지 반환

## 테스트 결과

- 실행 명령어:
  - `node --check .github/scripts/notion-sync.mjs`
- 결과 요약:
  - 문법 체크 통과
