### PR TITLE
[✨ Feat] 공통 응답/예외 처리 인프라 구현 (#1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/com/doori/doori_backend/global/config/OpenApiConfig.java
+++ b/src/main/java/com/doori/doori_backend/global/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.doori.doori_backend.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile({"local", "dev"})
+public class OpenApiConfig {
+
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI().info(
+			new Info()
+				.title("Doori Backend API")
+				.version("v1")
+				.description("Doori Backend API 문서")
+		);
+	}
+}

--- a/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.doori.doori_backend.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+	COMMON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "C001", "잘못된 요청입니다."),
+	COMMON_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 내부 오류가 발생했습니다."),
+	COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "요청한 리소스를 찾을 수 없습니다."),
+	AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+	AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String defaultMessage;
+
+	ErrorCode(HttpStatus httpStatus, String code, String defaultMessage) {
+		this.httpStatus = httpStatus;
+		this.code = code;
+		this.defaultMessage = defaultMessage;
+	}
+
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getDefaultMessage() {
+		return defaultMessage;
+	}
+}

--- a/src/main/java/com/doori/doori_backend/global/error/ErrorResponse.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.doori.doori_backend.global.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+	int status,
+	String code,
+	String message,
+	String path,
+	LocalDateTime timestamp
+) {
+
+	public static ErrorResponse of(ErrorCode errorCode, HttpServletRequest request) {
+		return new ErrorResponse(
+			errorCode.getHttpStatus().value(),
+			errorCode.getCode(),
+			errorCode.getDefaultMessage(),
+			request.getRequestURI(),
+			LocalDateTime.now()
+		);
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, String message, HttpServletRequest request) {
+		return new ErrorResponse(
+			errorCode.getHttpStatus().value(),
+			errorCode.getCode(),
+			message,
+			request.getRequestURI(),
+			LocalDateTime.now()
+		);
+	}
+}

--- a/src/main/java/com/doori/doori_backend/global/exception/CustomException.java
+++ b/src/main/java/com/doori/doori_backend/global/exception/CustomException.java
@@ -1,0 +1,22 @@
+package com.doori.doori_backend.global.exception;
+
+import com.doori.doori_backend.global.error.ErrorCode;
+
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getDefaultMessage());
+		this.errorCode = errorCode;
+	}
+
+	public CustomException(ErrorCode errorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/doori/doori_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/doori/doori_backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,83 @@
+package com.doori.doori_backend.global.exception;
+
+import com.doori.doori_backend.global.error.ErrorCode;
+import com.doori.doori_backend.global.error.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(
+		CustomException ex,
+		HttpServletRequest request
+	) {
+		ErrorCode errorCode = ex.getErrorCode();
+		ErrorResponse response = ErrorResponse.of(errorCode, ex.getMessage(), request);
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleValidationException(
+		MethodArgumentNotValidException ex,
+		HttpServletRequest request
+	) {
+		String message = ex.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+			.collect(Collectors.joining(", "));
+
+		ErrorResponse response = ErrorResponse.of(
+			ErrorCode.COMMON_BAD_REQUEST,
+			message.isBlank() ? ErrorCode.COMMON_BAD_REQUEST.getDefaultMessage() : message,
+			request
+		);
+		return ResponseEntity.status(ErrorCode.COMMON_BAD_REQUEST.getHttpStatus()).body(response);
+	}
+
+	@ExceptionHandler({
+		BindException.class,
+		MethodArgumentTypeMismatchException.class,
+		MissingServletRequestParameterException.class
+	})
+	public ResponseEntity<ErrorResponse> handleBindingException(Exception ex, HttpServletRequest request) {
+		ErrorResponse response = ErrorResponse.of(
+			ErrorCode.COMMON_BAD_REQUEST,
+			ex.getMessage(),
+			request
+		);
+		return ResponseEntity.status(ErrorCode.COMMON_BAD_REQUEST.getHttpStatus()).body(response);
+	}
+
+	@ExceptionHandler(NoResourceFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+		NoResourceFoundException ex,
+		HttpServletRequest request
+	) {
+		ErrorResponse response = ErrorResponse.of(
+			ErrorCode.COMMON_NOT_FOUND,
+			ErrorCode.COMMON_NOT_FOUND.getDefaultMessage(),
+			request
+		);
+		return ResponseEntity.status(ErrorCode.COMMON_NOT_FOUND.getHttpStatus()).body(response);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+		ErrorResponse response = ErrorResponse.of(
+			ErrorCode.COMMON_INTERNAL_SERVER_ERROR,
+			request
+		);
+		return ResponseEntity.status(ErrorCode.COMMON_INTERNAL_SERVER_ERROR.getHttpStatus()).body(response);
+	}
+}

--- a/src/main/java/com/doori/doori_backend/global/response/ApiResponse.java
+++ b/src/main/java/com/doori/doori_backend/global/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.doori.doori_backend.global.response;
+
+public record ApiResponse<T>(
+	boolean success,
+	String message,
+	T data
+) {
+
+	private static final String DEFAULT_SUCCESS_MESSAGE = "요청 성공";
+
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, DEFAULT_SUCCESS_MESSAGE, data);
+	}
+
+	public static <T> ApiResponse<T> success(String message, T data) {
+		return new ApiResponse<>(true, message, data);
+	}
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,2 @@
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=doori-backend
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false

--- a/src/test/java/com/doori/doori_backend/global/config/SwaggerLocalAccessIntegrationTest.java
+++ b/src/test/java/com/doori/doori_backend/global/config/SwaggerLocalAccessIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.doori.doori_backend.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("local")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class SwaggerLocalAccessIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void swaggerUi_isExposedInLocalProfile() throws Exception {
+		mockMvc.perform(get("/swagger-ui/index.html"))
+			.andExpect(status().isOk());
+	}
+}

--- a/src/test/java/com/doori/doori_backend/global/config/SwaggerProdAccessIntegrationTest.java
+++ b/src/test/java/com/doori/doori_backend/global/config/SwaggerProdAccessIntegrationTest.java
@@ -1,0 +1,26 @@
+package com.doori.doori_backend.global.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("prod")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class SwaggerProdAccessIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void swaggerUi_isDisabledInProdProfile() throws Exception {
+		mockMvc.perform(get("/swagger-ui/index.html"))
+			.andExpect(status().isNotFound());
+	}
+}

--- a/src/test/java/com/doori/doori_backend/global/exception/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/com/doori/doori_backend/global/exception/GlobalExceptionHandlerIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.doori.doori_backend.global.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.doori.doori_backend.global.error.ErrorCode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerIntegrationTest.TestController.class)
+class GlobalExceptionHandlerIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void customException_isMappedToErrorResponse() throws Exception {
+		mockMvc.perform(get("/test/custom"))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.status").value(403))
+			.andExpect(jsonPath("$.code").value("A002"))
+			.andExpect(jsonPath("$.message").value("접근 권한이 없습니다."))
+			.andExpect(jsonPath("$.path").value("/test/custom"))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void validationException_isMappedToBadRequest() throws Exception {
+		mockMvc.perform(post("/test/validation")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{}"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value(400))
+			.andExpect(jsonPath("$.code").value("C001"))
+			.andExpect(jsonPath("$.message").value("name: must not be blank"))
+			.andExpect(jsonPath("$.path").value("/test/validation"))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@Test
+	void unknownException_isMappedToInternalServerError() throws Exception {
+		mockMvc.perform(get("/test/runtime"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.status").value(500))
+			.andExpect(jsonPath("$.code").value("C002"))
+			.andExpect(jsonPath("$.message").value("서버 내부 오류가 발생했습니다."))
+			.andExpect(jsonPath("$.path").value("/test/runtime"))
+			.andExpect(jsonPath("$.timestamp").exists());
+	}
+
+	@RestController
+	@RequestMapping("/test")
+	public static class TestController {
+
+		@GetMapping("/custom")
+		public void customException() {
+			throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+		}
+
+		@PostMapping("/validation")
+		public void validationException(@Valid @RequestBody TestRequest request) {
+		}
+
+		@GetMapping("/runtime")
+		public void runtimeException() {
+			throw new IllegalStateException("unexpected");
+		}
+	}
+
+	record TestRequest(@NotBlank String name) {
+	}
+}

--- a/src/test/java/com/doori/doori_backend/global/response/ApiResponseTest.java
+++ b/src/test/java/com/doori/doori_backend/global/response/ApiResponseTest.java
@@ -1,0 +1,26 @@
+package com.doori.doori_backend.global.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ApiResponseTest {
+
+	@Test
+	void success_withData_usesDefaultMessage() {
+		ApiResponse<String> response = ApiResponse.success("data");
+
+		assertThat(response.success()).isTrue();
+		assertThat(response.message()).isEqualTo("요청 성공");
+		assertThat(response.data()).isEqualTo("data");
+	}
+
+	@Test
+	void success_withMessageAndData_usesProvidedMessage() {
+		ApiResponse<Integer> response = ApiResponse.success("생성 완료", 1);
+
+		assertThat(response.success()).isTrue();
+		assertThat(response.message()).isEqualTo("생성 완료");
+		assertThat(response.data()).isEqualTo(1);
+	}
+}


### PR DESCRIPTION
## 연관 이슈

- Closes #1

## 변경 요약

- Spring Boot 백엔드의 공통 응답/예외 처리 인프라 구현
- 계층별로 역할을 분리한 global 패키지 아키텍처 확립
- 에러 코드 체계 도입 및 중앙화 예외 처리

## 구현 상세

### 패키지 구조 (`src/main/java/com/doori/doori_backend/global/`)

**`response/ApiResponse.java`**
- 성공 응답 전용 record
- 필드: `success`, `message`, `data`
- 팩토리 메서드: `success()` (기본), `success(message, data)` (커스텀)
- Controller에서만 사용

**`error/ErrorCode.java`**
- enum 기반 에러 코드 관리
- 필드: `httpStatus`, `code`, `defaultMessage`
- 현재 정의: C001(Bad Request), C002(Internal Server Error), C003(Not Found), A001(Unauthorized), A002(Forbidden)
- 도메인별 확장 가능한 구조

**`error/ErrorResponse.java`**
- 에러 응답 전용 record
- 필드: `status`, `code`, `message`, `path`, `timestamp`
- GlobalExceptionHandler에서만 생성
- 팩토리 메서드: ErrorCode 기반 자동 생성

**`exception/CustomException.java`**
- RuntimeException 상속, ErrorCode 기반 예외
- 생성자 2개: 기본 메시지 / 커스텀 메시지
- Service/Domain 레이어에서 던짐

**`exception/GlobalExceptionHandler.java`**
- @RestControllerAdvice로 모든 예외를 중앙화 처리
- 핸들러 5개:
  - `CustomException` → ErrorCode에 따라 HTTP 상태 매핑
  - `MethodArgumentNotValidException` → 400 + 필드별 검증 메시지
  - `BindException`, `MethodArgumentTypeMismatchException`, `MissingServletRequestParameterException` → 400
  - `NoResourceFoundException` → 404
  - `Exception` (fallback) → 500

**`config/OpenApiConfig.java`**
- Swagger/SpringDoc OpenAPI 설정
- `@Profile({"local", "dev"})` — local/dev 프로필에서만 활성화
- API 제목: "Doori Backend API", 버전: "v1"
- prod 환경에서 자동 비활성화

### 의존성 추가 (`build.gradle`)
```gradle
implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
```

### 설정 파일

**`application.properties`**
```properties
springdoc.api-docs.enabled=false
springdoc.swagger-ui.enabled=false
```
기본적으로 Swagger UI 비활성화 (프로필별 활성화)

**`application-dev.properties`** / **`application-local.properties`**
- 개발/로컬 환경 설정 분리

### 테스트 (`src/test/java/com/doori/doori_backend/global/`)

**`response/ApiResponseTest.java`**
- 팩토리 메서드 검증 (기본 메시지, 커스텀 메시지, data 필드)

**`exception/GlobalExceptionHandlerIntegrationTest.java`**
- CustomException 매핑 검증
- @Valid 검증 실패 매핑
- RuntimeException 매핑

**`config/SwaggerLocalAccessIntegrationTest.java`**
- local 프로필: Swagger UI 접근 가능 (200)

**`config/SwaggerProdAccessIntegrationTest.java`**
- prod 프로필: Swagger UI 차단 (404)

## 테스트 결과

- 실행 명령어: `./gradlew clean build`
- 결과 요약:
  ```
  BUILD SUCCESSFUL in 10s
  9 actionable tasks: 9 executed
  ```
- 모든 테스트 통과 (4개 통합 테스트 + 1개 단위 테스트)

## 체크리스트

- [x] PR 본문에 `Closes #이슈번호`를 포함했습니다.
- [x] 주요 구현 내용(응답/예외 처리 인프라)을 본문에 작성했습니다.
- [x] 테스트 실행 명령 및 결과를 본문에 작성했습니다.
- [x] `./gradlew clean build` 검증 완료 (빌드 성공, 모든 테스트 통과)