### PR TITLE
chore: MySQL연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,2 +1,10 @@
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
+
+spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/doori?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=${DB_USERNAME:root}
+spring.datasource.password=${DB_PASSWORD:}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-local.properties.example
+++ b/src/main/resources/application-local.properties.example
@@ -1,18 +1,19 @@
 # ---------------------------------------------------------------
 # 이 파일을 복사해서 application-local.properties 로 저장 후 값을 채우세요.
 # application-local.properties 는 .gitignore 에 등록되어 있으므로 커밋되지 않습니다.
+# 사전 준비: MySQL에서 `CREATE DATABASE doori;` 실행 필요
 # ---------------------------------------------------------------
 
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 
-spring.datasource.url=jdbc:h2:mem:doori;MODE=MySQL;DB_CLOSE_DELAY=-1
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.h2.console.enabled=true
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=jdbc:mysql://localhost:3306/doori?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=<MySQL 사용자명>
+spring.datasource.password=<MySQL 비밀번호>
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/src/main/resources/application-local.properties.example
+++ b/src/main/resources/application-local.properties.example
@@ -1,7 +1,9 @@
 # ---------------------------------------------------------------
-# 이 파일을 복사해서 application-local.properties 로 저장 후 값을 채우세요.
-# application-local.properties 는 .gitignore 에 등록되어 있으므로 커밋되지 않습니다.
-# 사전 준비: MySQL에서 `CREATE DATABASE doori;` 실행 필요
+# 로컬 실행 전 준비 순서:
+# 1) 이 파일을 복사해서 application-local.properties 로 저장하고 아래 값을 채우세요.
+# 2) application-local.properties 는 .gitignore 에 등록되어 있으므로 커밋되지 않습니다.
+# 3) MySQL에서 `CREATE DATABASE doori;` 를 먼저 실행하세요.
+# 4) 위 설정을 마친 뒤에만 `./gradlew bootRun` 으로 애플리케이션을 실행하세요.
 # ---------------------------------------------------------------
 
 springdoc.api-docs.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,14 @@
 spring.application.name=doori-backend
+spring.profiles.active=local
 springdoc.api-docs.enabled=false
 springdoc.swagger-ui.enabled=false
+
+spring.datasource.url=${DB_URL:jdbc:h2:mem:doori;MODE=MySQL;DB_CLOSE_DELAY=-1}
+spring.datasource.driver-class-name=${DB_DRIVER_CLASS_NAME:org.h2.Driver}
+spring.datasource.username=${DB_USERNAME:sa}
+spring.datasource.password=${DB_PASSWORD:}
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 jwt.secret=${JWT_SECRET:doori-backend-secret-key-for-development-only-must-be-32chars}
 jwt.access-token-valid-ms=3600000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,10 +3,6 @@ spring.profiles.active=local
 springdoc.api-docs.enabled=false
 springdoc.swagger-ui.enabled=false
 
-spring.datasource.url=${DB_URL:jdbc:h2:mem:doori;MODE=MySQL;DB_CLOSE_DELAY=-1}
-spring.datasource.driver-class-name=${DB_DRIVER_CLASS_NAME:org.h2.Driver}
-spring.datasource.username=${DB_USERNAME:sa}
-spring.datasource.password=${DB_PASSWORD:}
 spring.jpa.hibernate.ddl-auto=none
 
 jwt.secret=${JWT_SECRET:doori-backend-secret-key-for-development-only-must-be-32chars}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,6 @@ spring.datasource.driver-class-name=${DB_DRIVER_CLASS_NAME:org.h2.Driver}
 spring.datasource.username=${DB_USERNAME:sa}
 spring.datasource.password=${DB_PASSWORD:}
 spring.jpa.hibernate.ddl-auto=none
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 jwt.secret=${JWT_SECRET:doori-backend-secret-key-for-development-only-must-be-32chars}
 jwt.access-token-valid-ms=3600000


### PR DESCRIPTION
## 연관 이슈

- Closes #16 

## 변경 요약

- H2 인메모리 DB → 로컬 MySQL DB로 변경     
- 서버 재시작 시 데이터 유실 문제 해결

## 구현 상세

  - build.gradle: runtimeOnly 'com.h2database:h2' → runtimeOnly 'com.mysql:mysql-connector-j' 변경 (H2는        
  testRuntimeOnly 유지)                                                                                         
  - application.properties: MySQL datasource 설정 추가, 기본 프로필 local로 설정
  - application-dev.properties: dev 환경 MySQL 설정 추가 (ddl-auto=update)
  - application-local.properties.example: H2 → MySQL 템플릿으로 업데이트

## 테스트 결과

- 실행 명령어:./gradlew clean build
- 결과 요약: BUILD SUCCESSFUL, 전체 테스트 통과

## 체크리스트

- [x] PR 본문에 `Closes #이슈번호` 또는 `Fixes #이슈번호`를 포함했습니다.
- [x] 주요 구현 내용(특히 API/DB 변경 사항)을 본문에 작성했습니다.
- [x] 로컬 검증 명령을 실행했고 결과를 본문에 작성했습니다.
