### PR TITLE
[✨ Feat] Post API 기본 CRUD 및 목록/상세 조회 구현 (#22)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,309 @@
+# Post API 구현 Roadmap
+
+**이슈**: #22 — Post API 기본 CRUD 및 목록/상세 조회 기능 구현  
+**브랜치**: `feat/22-post-api`  
+**예상 총 소요 시간**: 3-4일
+
+---
+
+## 개발 단계
+
+### Phase 1: 프로젝트 초기 설정 (골격 구축)
+
+#### 작업 내용
+- [ ] `ErrorCode.java`에 Post 도메인 에러 코드 추가
+  - `POST_NOT_FOUND (P001)` — 게시글을 찾을 수 없습니다.
+  - `POST_FORBIDDEN (P002)` — 게시글을 수정하거나 삭제할 권한이 없습니다.
+- [ ] 디렉토리 구조 생성
+  ```
+  src/main/java/com/doori/doori_backend/post/
+  ├── controller/
+  ├── domain/
+  ├── dto/
+  │   ├── request/
+  │   └── response/
+  ├── repository/
+  └── service/
+  ```
+
+#### 왜 이 순서로?
+새로운 도메인의 기반이 되는 **에러 정의**와 **디렉토리 구조**를 먼저 구축해야 일관된 계층 구조를 유지할 수 있습니다. 이를 통해 이후 개발에서 규칙을 쉽게 따를 수 있습니다.
+
+#### 예상 소요 시간
+**30분 ~ 1시간**
+
+#### 완료 기준
+- [ ] ErrorCode에 P001, P002 정상 추가
+- [ ] 5개 디렉토리 생성 완료
+- [ ] `./gradlew clean build` 성공 (컴파일 에러 없음)
+
+---
+
+### Phase 2: 공통 모듈/컴포넌트 개발
+
+#### 작업 내용
+- [ ] **DTO 정의** (4개 클래스)
+  - `PostCreateRequest.java` — 게시글 생성 요청
+  - `PostUpdateRequest.java` — 게시글 수정 요청
+  - `PostResponse.java` — 게시글 응답 (from() 변환 메서드 포함)
+  - `PostListResponse.java` — 게시글 목록 응답
+  
+- [ ] **Enum 정의**
+  - `PostType.java` — TRANSFER, SUBLEASE, WANTED
+
+#### 왜 이 순서로?
+DTO와 Enum은 엔티티, Repository, Service, Controller에서 공통으로 사용되는 **계약(Contract)**입니다. 먼저 정의하면 이후 계층들을 일관되게 구현할 수 있습니다.
+
+#### 예상 소요 시간
+**30분 ~ 45분**
+
+#### 완료 기준
+- [ ] 4개 DTO 클래스 작성 완료
+- [ ] PostResponse.from() 메서드 구현
+- [ ] PostListResponse.from() 메서드 구현
+- [ ] PostType Enum 3가지 타입 정의
+- [ ] `./gradlew clean build` 성공
+
+---
+
+### Phase 3: 핵심 기능 개발
+
+#### 작업 내용
+
+**3-1. 도메인 엔티티 구현** (45분 ~ 1시간)
+- [ ] `Post.java` 엔티티 구현
+  - 필드: postId, postType, title, region, university, monthlyRent, deposit, description, roomImages (ElementCollection)
+  - 관계: ManyToOne으로 Member(author)
+  - 메서드: `update()` (수정), `isOwnedBy()` (소유권 확인)
+  - JPA Auditing: createdAt, updatedAt
+
+**3-2. Repository 구현** (30분 ~ 45분)
+- [ ] `PostRepository.java` 구현
+  - 기본 CRUD: JpaRepository 상속
+  - 커스텀 쿼리: `findAllByFilter(postType, pageable)` — postType 필터링
+
+**3-3. Service 구현** (1시간 ~ 1시간 30분)
+- [ ] `PostService.java` 구현
+  - `createPost()` — 게시글 생성, 201 반환
+  - `getPosts()` — 목록 조회 (필터, 페이지네이션)
+  - `getPost()` — 단건 상세 조회
+  - `updatePost()` — 소유권 검증 후 수정
+  - `deletePost()` — 소유권 검증 후 삭제
+  - 헬퍼 메서드: `findPost()`, `validateOwnership()`, `findActiveMember()`, `parsePostType()`
+  - 모든 메서드에 `@Transactional` 적용
+
+**3-4. Controller 구현** (45분 ~ 1시간)
+- [ ] `PostController.java` 구현
+  - `POST /api/posts` → createPost() → 201 + ApiResponse
+  - `GET /api/posts` → getPosts() → 200 + ApiResponse
+  - `GET /api/posts/{postId}` → getPost() → 200 + ApiResponse
+  - `PUT /api/posts/{postId}` → updatePost() → 204 Void
+  - `DELETE /api/posts/{postId}` → deletePost() → 204 Void
+  - 모든 메서드: `ResponseEntity<ApiResponse<T>>` 또는 `ResponseEntity<Void>` 패턴
+
+#### 왜 이 순서로?
+엔티티 → Repository → Service → Controller 순서는 **의존성 방향**을 따릅니다:
+- Service는 Repository에 의존
+- Controller는 Service에 의존
+
+이 순서로 구현하면 각 계층을 테스트하면서 진행할 수 있고, 컴파일 에러를 단계적으로 해결할 수 있습니다.
+
+#### 예상 소요 시간
+**4시간 ~ 5시간**
+
+#### 완료 기준
+- [ ] Post 엔티티 구현 완료 (테스트 DB에서 스키마 자동 생성)
+- [ ] PostRepository 기본 메서드 동작 확인
+- [ ] PostService 비즈니스 로직 구현 완료
+- [ ] PostController 5개 엔드포인트 구현 완료
+- [ ] `./gradlew clean build` 성공 (컴파일 에러 없음)
+- [ ] `./gradlew bootRun` 실행 시 서버 정상 시작
+
+---
+
+### Phase 4: 추가 기능 개발 (테스트 작성)
+
+#### 작업 내용
+- [ ] **통합 테스트 작성** — `PostControllerIntegrationTest.java`
+  - 테스트 환경: `@SpringBootTest` + H2 + `addFilters=false`
+  - 인증 모킹: `SecurityContextHolder` 수동 주입
+  - 테스트 케이스 12개:
+    ```
+    [생성] createPost_success, createPost_missingField_returns400
+    [목록] getPosts_noFilter_returnsAll, getPosts_withFilter, getPosts_invalidType_returns400
+    [상세] getPost_exists_returns200, getPost_notFound_returns404
+    [수정] updatePost_owner_returns204, updatePost_notOwner_returns403, updatePost_notFound_returns404
+    [삭제] deletePost_owner_returns204, deletePost_notOwner_returns403, deletePost_notFound_returns404
+    ```
+
+#### 왜 이 순서로?
+핵심 기능 구현 후 테스트를 작성합니다. 이를 통해:
+- 실제 동작 검증
+- 엣지 케이스 발견
+- 리팩토링 안정성 확보
+
+#### 예상 소요 시간
+**1시간 30분 ~ 2시간**
+
+#### 완료 기준
+- [ ] PostControllerIntegrationTest 작성 완료
+- [ ] 12개 테스트 케이스 모두 GREEN (통과)
+- [ ] `./gradlew test` 전체 테스트 통과
+- [ ] 테스트 커버리지 80% 이상 (선택사항)
+
+---
+
+### Phase 5: 최적화 및 배포
+
+#### 작업 내용
+- [ ] **코드 리뷰 및 정리**
+  - response-exception.md 규칙 체크
+  - 불필요한 임포트 정리
+  - 로그 레벨 확인
+  - 테스트 격리 확인 (@Transactional 롤백)
+
+- [ ] **수동 테스트** (API 검증)
+  - `./gradlew bootRun` 실행
+  - Postman/curl로 5개 엔드포인트 모두 테스트
+    ```bash
+    # 생성 (201)
+    curl -X POST http://localhost:8080/api/posts \
+      -H "Authorization: Bearer {token}" \
+      -H "Content-Type: application/json" \
+      -d '{"postType":"TRANSFER","title":"...","region":"마포구",...}'
+    
+    # 목록 (200)
+    curl http://localhost:8080/api/posts?postType=TRANSFER
+    
+    # 상세 (200 or 404)
+    curl http://localhost:8080/api/posts/1
+    
+    # 수정 (204 or 403)
+    curl -X PUT http://localhost:8080/api/posts/1 -H "Authorization: Bearer {token}" -d '{...}'
+    
+    # 삭제 (204 or 403)
+    curl -X DELETE http://localhost:8080/api/posts/1 -H "Authorization: Bearer {token}"
+    ```
+
+- [ ] **PR 생성 및 리뷰**
+  - 커밋 메시지: `feat: ✨ Post API 기본 CRUD 및 목록/상세 조회 구현 (#22)`
+  - PR 본문에 Closes #22 포함
+  - CI 통과 확인
+  - 팀 리뷰 승인
+
+- [ ] **main 브랜치 병합**
+  - PR 머지
+  - 배포 (필요시)
+
+#### 왜 이 단계가 필요한가?
+완성도 있는 코드를 프로젝트에 통합하기 위해:
+- 규칙 준수 확인
+- 실제 사용 가능성 검증
+- 팀 협업 프로세스 이행
+
+#### 예상 소요 시간
+**1시간 ~ 1시간 30분**
+
+#### 완료 기준
+- [ ] response-exception.md 체크리스트 모두 체크 완료
+- [ ] 수동 테스트 5개 엔드포인트 모두 정상 동작 확인
+- [ ] 모든 테스트 통과 (./gradlew test)
+- [ ] PR 머지 완료
+- [ ] Notion DB 자동 동기화 확인 (이슈 상태 변경)
+
+---
+
+## 타임라인 요약
+
+| Phase | 작업 | 예상 시간 | 누적 시간 |
+|-------|------|---------|---------|
+| 1 | 초기 설정 (ErrorCode, 디렉토리) | 30-60분 | 30-60분 |
+| 2 | DTO, Enum 정의 | 30-45분 | 1-1.75시간 |
+| 3 | 엔티티, Repo, Service, Controller | 4-5시간 | 5-6.75시간 |
+| 4 | 통합 테스트 작성 | 1.5-2시간 | 6.5-8.75시간 |
+| 5 | 리뷰, 수동 테스트, PR 병합 | 1-1.5시간 | 7.5-10.25시간 |
+| **총** | | | **7.5-10시간** |
+
+**권장**: 2-3일에 걸쳐 진행 (하루 3-4시간 작업)
+
+---
+
+## 중요 주의사항
+
+### 핵심 규칙 (반드시 준수)
+
+1. **@ElementCollection 관리**
+   - `roomImages` 필드의 값 변경은 Service 트랜잭션 내에서만
+   - Controller에서 Post 엔티티 직접 접근 금지 → LazyInitializationException 위험
+
+2. **계층 경계 준수**
+   - Controller: `ResponseEntity<ApiResponse<T>>` 또는 `ResponseEntity<Void>`만 반환
+   - Service: `CustomException` 사용, ApiResponse 미반환
+   - Repository: 엔티티만 반환
+
+3. **ErrorCode 네이밍**
+   - Post 도메인 전용: `P` 접두사
+   - 한번 부여한 코드 번호(P001, P002)는 변경/삭제 금지
+
+4. **트랜잭션 관리**
+   - `createPost()`, `updatePost()`, `deletePost()`: `@Transactional`
+   - `getPost()`, `getPosts()`: `@Transactional(readOnly=true)`
+
+### 테스트 시 주의
+
+- SecurityContext 설정 후 테스트 실행
+- 각 테스트 후 `SecurityContextHolder.clearContext()` 호출
+- `@Transactional`로 테스트 간 데이터 격리
+
+### 커밋 가이드
+
+각 Phase마다 하나의 커밋으로 작성:
+
+```bash
+# Phase 1
+git add src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+git commit -m "chore: 🧹 Post 도메인 ErrorCode 추가 (P001, P002)"
+
+# Phase 2
+git add src/main/java/com/doori/doori_backend/post/dto/
+git add src/main/java/com/doori/doori_backend/post/domain/PostType.java
+git commit -m "feat: ✨ Post API DTO 및 PostType Enum 정의"
+
+# Phase 3
+git add src/main/java/com/doori/doori_backend/post/
+git commit -m "feat: ✨ Post API 엔티티, Repository, Service, Controller 구현"
+
+# Phase 4
+git add src/test/java/com/doori/doori_backend/post/
+git commit -m "test: 📝 Post API 통합 테스트 작성 (12개 케이스)"
+
+# Phase 5
+git commit -m "Merge pull request #22"
+```
+
+---
+
+## 완료 체크리스트
+
+### 구현 완료
+- [ ] Phase 1: 초기 설정 완료
+- [ ] Phase 2: DTO/Enum 완료
+- [ ] Phase 3: 엔티티/Repo/Service/Controller 완료
+- [ ] Phase 4: 통합 테스트 완료
+- [ ] Phase 5: 코드 리뷰 및 수동 테스트 완료
+
+### 규칙 준수
+- [ ] response-exception.md 규칙 모두 체크
+- [ ] commit.md 브랜치/커밋 네이밍 규칙 준수
+- [ ] 테스트 모두 GREEN
+
+### 배포 준비
+- [ ] PR 작성 (Closes #22 포함)
+- [ ] CI 통과
+- [ ] 팀 리뷰 승인
+- [ ] main 브랜치 병합
+
+---
+
+**Last Updated**: 2026-05-19  
+**Status**: Ready for Implementation ✅

--- a/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode {
 	SCHOOL_UNSUPPORTED_EMAIL(HttpStatus.BAD_REQUEST, "S001", "지원하지 않는 학교 이메일입니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
 	USER_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "U002", "이미 사용 중인 닉네임입니다."),
-	USER_LIFESTYLE_PROFILE_REQUIRED(HttpStatus.BAD_REQUEST, "U003", "생활 상황 프로필을 먼저 완성해주세요.");
+	USER_LIFESTYLE_PROFILE_REQUIRED(HttpStatus.BAD_REQUEST, "U003", "생활 상황 프로필을 먼저 완성해주세요."),
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "게시글을 찾을 수 없습니다."),
+	POST_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "게시글에 대한 접근 권한이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/doori/doori_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/doori/doori_backend/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.error.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,6 +18,8 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse> handleCustomException(
@@ -76,6 +80,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+		log.error("처리되지 않은 예외 발생: {}", ex.getMessage(), ex);
 		ErrorResponse response = ErrorResponse.of(
 			ErrorCode.COMMON_INTERNAL_SERVER_ERROR,
 			request

--- a/src/main/java/com/doori/doori_backend/post/controller/PostController.java
+++ b/src/main/java/com/doori/doori_backend/post/controller/PostController.java
@@ -1,0 +1,107 @@
+package com.doori.doori_backend.post.controller;
+
+import com.doori.doori_backend.global.response.ApiResponse;
+import com.doori.doori_backend.post.dto.request.PostCreateRequest;
+import com.doori.doori_backend.post.dto.request.PostUpdateRequest;
+import com.doori.doori_backend.post.dto.response.PostListResponse.Wrapper;
+import com.doori.doori_backend.post.dto.response.PostResponse;
+import com.doori.doori_backend.post.service.PostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Post API 컨트롤러
+ * - 모든 엔드포인트는 JWT 인증 필요 (SecurityConfig에서 anyRequest().authenticated() 적용)
+ * - Authentication.getPrincipal()로 memberId(Long) 추출
+ * - 예외 처리는 GlobalExceptionHandler에 위임, Controller는 try-catch 없음
+ */
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    /**
+     * 게시글 생성
+     * POST /api/posts → 201 Created
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<PostResponse>> createPost(
+        @RequestBody @Valid PostCreateRequest request,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        PostResponse response = postService.createPost(memberId, request);
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success("게시글이 등록되었습니다.", response));
+    }
+
+    /**
+     * 게시글 목록 조회 (필터 + 페이지네이션)
+     * GET /api/posts?postType=TRANSFER&page=0&size=10 → 200 OK
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Wrapper>> getPosts(
+        @RequestParam(required = false) String postType,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Wrapper response = postService.getPosts(postType, page, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 게시글 단건 조회
+     * GET /api/posts/{postId} → 200 OK
+     */
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(
+        @PathVariable Long postId
+    ) {
+        PostResponse response = postService.getPost(postId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 게시글 수정
+     * PUT /api/posts/{postId} → 204 No Content
+     */
+    @PutMapping("/{postId}")
+    public ResponseEntity<Void> updatePost(
+        @PathVariable Long postId,
+        @RequestBody @Valid PostUpdateRequest request,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        postService.updatePost(memberId, postId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 게시글 삭제
+     * DELETE /api/posts/{postId} → 204 No Content
+     */
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(
+        @PathVariable Long postId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        postService.deletePost(memberId, postId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/doori/doori_backend/post/domain/Post.java
+++ b/src/main/java/com/doori/doori_backend/post/domain/Post.java
@@ -1,0 +1,147 @@
+package com.doori.doori_backend.post.domain;
+
+import com.doori.doori_backend.auth.domain.Member;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 게시글 엔티티
+ * - author: LAZY 로딩으로 성능 최적화, 조회 시 트랜잭션 내에서 접근해야 함
+ * - roomImages: @ElementCollection으로 별도 테이블에 저장, 트랜잭션 내 접근 필수
+ */
+@Entity
+@Table(name = "post")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    // 작성자 — LAZY 로딩: N+1 방지를 위해 필요 시 fetch join 사용
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member author;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PostType postType;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String region;
+
+    @Column(nullable = false)
+    private String university;
+
+    // 월세 (nullable: WANTED 타입은 선택값일 수 있음)
+    private Integer monthlyRent;
+
+    // 보증금 (nullable: WANTED 타입은 선택값일 수 있음)
+    private Integer deposit;
+
+    // 본문 설명 — TEXT로 긴 내용 저장 허용
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    // 방 사진 URL 목록 — 별도 테이블로 관리
+    @ElementCollection
+    @CollectionTable(name = "post_room_image", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "image_url")
+    private List<String> roomImages = new ArrayList<>();
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Post(
+        Member author,
+        PostType postType,
+        String title,
+        String region,
+        String university,
+        Integer monthlyRent,
+        Integer deposit,
+        String description,
+        List<String> roomImages
+    ) {
+        this.author = author;
+        this.postType = postType;
+        this.title = title;
+        this.region = region;
+        this.university = university;
+        this.monthlyRent = monthlyRent;
+        this.deposit = deposit;
+        this.description = description;
+        if (roomImages != null) {
+            this.roomImages.addAll(roomImages);
+        }
+    }
+
+    /**
+     * 게시글 전체 수정 (full-update 방식)
+     * roomImages는 기존 목록을 clear 후 새 목록으로 교체한다.
+     * @ElementCollection 특성상 orphan removal이 자동 처리된다.
+     */
+    public void update(
+        PostType postType,
+        String title,
+        String region,
+        String university,
+        Integer monthlyRent,
+        Integer deposit,
+        String description,
+        List<String> roomImages
+    ) {
+        this.postType = postType;
+        this.title = title;
+        this.region = region;
+        this.university = university;
+        this.monthlyRent = monthlyRent;
+        this.deposit = deposit;
+        this.description = description;
+        this.roomImages.clear();
+        if (roomImages != null) {
+            this.roomImages.addAll(roomImages);
+        }
+    }
+
+    /**
+     * 게시글 소유권 검증
+     * @param memberId 현재 요청한 사용자 ID
+     * @return 작성자 본인이면 true
+     */
+    public boolean isOwnedBy(Long memberId) {
+        return this.author.getId().equals(memberId);
+    }
+}

--- a/src/main/java/com/doori/doori_backend/post/domain/PostType.java
+++ b/src/main/java/com/doori/doori_backend/post/domain/PostType.java
@@ -1,0 +1,13 @@
+package com.doori.doori_backend.post.domain;
+
+/**
+ * 게시글 유형을 나타내는 Enum
+ * - TRANSFER: 양도 (기존 계약 양도)
+ * - SUBLEASE: 전대 (단기 재임대)
+ * - WANTED: 구해요 (룸메이트/방 구하는 글)
+ */
+public enum PostType {
+	TRANSFER,
+	SUBLEASE,
+	WANTED
+}

--- a/src/main/java/com/doori/doori_backend/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/doori/doori_backend/post/dto/request/PostCreateRequest.java
@@ -1,0 +1,39 @@
+package com.doori.doori_backend.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+/**
+ * 게시글 생성 요청 DTO
+ * - postType: 게시글 유형 (TRANSFER/SUBLEASE/WANTED), 문자열로 받아 서비스에서 변환
+ * - roomImages: 방 사진 URL 목록 (선택값, 최대 5장 권장)
+ */
+public record PostCreateRequest(
+	@NotNull(message = "게시글 유형은 필수입니다.")
+	String postType,
+
+	@NotBlank(message = "제목은 필수입니다.")
+	String title,
+
+	@NotBlank(message = "지역은 필수입니다.")
+	String region,
+
+	@NotBlank(message = "대학교는 필수입니다.")
+	String university,
+
+	@NotNull(message = "월세는 필수입니다.")
+	@Positive(message = "월세는 0보다 커야 합니다.")
+	Integer monthlyRent,
+
+	@NotNull(message = "보증금은 필수입니다.")
+	@Positive(message = "보증금은 0보다 커야 합니다.")
+	Integer deposit,
+
+	@NotBlank(message = "상세 설명은 필수입니다.")
+	String description,
+
+	List<String> roomImages
+) {
+}

--- a/src/main/java/com/doori/doori_backend/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/doori/doori_backend/post/dto/request/PostUpdateRequest.java
@@ -1,0 +1,40 @@
+package com.doori.doori_backend.post.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+/**
+ * 게시글 수정 요청 DTO
+ * - 수정 시에도 전체 필드를 다시 받는 full-update 방식
+ * - postType: 게시글 유형도 수정 가능 (문자열로 받아 서비스에서 변환)
+ * - roomImages: 수정된 방 사진 URL 목록 (null 허용, @ElementCollection 교체 방식)
+ */
+public record PostUpdateRequest(
+    @NotNull(message = "게시글 유형은 필수입니다.")
+    String postType,
+
+    @NotBlank(message = "제목은 필수입니다.")
+    String title,
+
+    @NotBlank(message = "지역은 필수입니다.")
+    String region,
+
+    @NotBlank(message = "대학교는 필수입니다.")
+    String university,
+
+    @NotNull(message = "월세는 필수입니다.")
+    @Positive(message = "월세는 0보다 커야 합니다.")
+    Integer monthlyRent,
+
+    @NotNull(message = "보증금은 필수입니다.")
+    @Positive(message = "보증금은 0보다 커야 합니다.")
+    Integer deposit,
+
+    @NotBlank(message = "상세 설명은 필수입니다.")
+    String description,
+
+    List<String> roomImages
+) {
+}

--- a/src/main/java/com/doori/doori_backend/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/doori/doori_backend/post/dto/response/PostListResponse.java
@@ -1,0 +1,62 @@
+package com.doori.doori_backend.post.dto.response;
+
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 게시글 목록 응답 DTO (아이템 단위)
+ * - 목록 조회 시 불필요한 description, roomImages를 제외해 응답 크기를 줄인다.
+ * - 썸네일은 roomImages 첫 번째 이미지를 사용한다.
+ */
+public record PostListResponse(
+    Long postId,
+    PostType postType,
+    String title,
+    String region,
+    String university,
+    Integer monthlyRent,
+    Integer deposit,
+    String thumbnailImageUrl,
+    Long authorId,
+    String authorNickname,
+    LocalDateTime createdAt
+) {
+
+    /**
+     * Post 엔티티를 PostListResponse 로 변환한다.
+     * thumbnailImageUrl은 roomImages의 첫 번째 항목이며, 없으면 null이다.
+     */
+    public static PostListResponse from(Post post) {
+        String thumbnail = post.getRoomImages().isEmpty()
+            ? null
+            : post.getRoomImages().get(0);
+
+        return new PostListResponse(
+            post.getPostId(),
+            post.getPostType(),
+            post.getTitle(),
+            post.getRegion(),
+            post.getUniversity(),
+            post.getMonthlyRent(),
+            post.getDeposit(),
+            thumbnail,
+            post.getAuthor().getId(),
+            post.getAuthor().getNickname(),
+            post.getCreatedAt()
+        );
+    }
+
+    /**
+     * 목록 래퍼 응답 레코드
+     * - posts: 게시글 목록 아이템
+     * - total: 필터 조건에 맞는 전체 게시글 수 (페이지네이션 클라이언트 처리용)
+     */
+    public record Wrapper(List<PostListResponse> posts, int total) {
+
+        public static Wrapper of(List<PostListResponse> posts, int total) {
+            return new Wrapper(posts, total);
+        }
+    }
+}

--- a/src/main/java/com/doori/doori_backend/post/dto/response/PostResponse.java
+++ b/src/main/java/com/doori/doori_backend/post/dto/response/PostResponse.java
@@ -1,0 +1,50 @@
+package com.doori.doori_backend.post.dto.response;
+
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 게시글 단건 상세 응답 DTO
+ * - from() 팩토리 메서드로 Post 엔티티를 변환
+ * - authorId, authorNickname: 작성자 정보 (Member 조인 없이 기본 정보만 노출)
+ */
+public record PostResponse(
+	Long postId,
+	PostType postType,
+	String title,
+	String region,
+	String university,
+	Integer monthlyRent,
+	Integer deposit,
+	String description,
+	List<String> roomImages,
+	Long authorId,
+	String authorNickname,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+
+	/**
+	 * Post 엔티티를 PostResponse 로 변환한다.
+	 * @ElementCollection인 roomImages는 트랜잭션 내에서 호출해야 LazyInitializationException을 방지할 수 있다.
+	 */
+	public static PostResponse from(Post post) {
+		return new PostResponse(
+			post.getPostId(),
+			post.getPostType(),
+			post.getTitle(),
+			post.getRegion(),
+			post.getUniversity(),
+			post.getMonthlyRent(),
+			post.getDeposit(),
+			post.getDescription(),
+			List.copyOf(post.getRoomImages()),
+			post.getAuthor().getId(),
+			post.getAuthor().getNickname(),
+			post.getCreatedAt(),
+			post.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/java/com/doori/doori_backend/post/repository/PostRepository.java
+++ b/src/main/java/com/doori/doori_backend/post/repository/PostRepository.java
@@ -1,0 +1,25 @@
+package com.doori.doori_backend.post.repository;
+
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * postType 필터링 + 최신순 정렬 목록 조회
+     * - postType이 null이면 전체 목록, 아니면 해당 타입만 반환
+     * - author를 fetch join하여 PostListResponse 변환 시 N+1 방지
+     */
+    @Query("""
+        SELECT p FROM Post p
+        JOIN FETCH p.author
+        WHERE (:postType IS NULL OR p.postType = :postType)
+        ORDER BY p.createdAt DESC
+        """)
+    Page<Post> findAllByFilter(@Param("postType") PostType postType, Pageable pageable);
+}

--- a/src/main/java/com/doori/doori_backend/post/service/PostService.java
+++ b/src/main/java/com/doori/doori_backend/post/service/PostService.java
@@ -1,0 +1,177 @@
+package com.doori.doori_backend.post.service;
+
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.auth.domain.MemberStatus;
+import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.global.error.ErrorCode;
+import com.doori.doori_backend.global.exception.CustomException;
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import com.doori.doori_backend.post.dto.request.PostCreateRequest;
+import com.doori.doori_backend.post.dto.request.PostUpdateRequest;
+import com.doori.doori_backend.post.dto.response.PostListResponse;
+import com.doori.doori_backend.post.dto.response.PostListResponse.Wrapper;
+import com.doori.doori_backend.post.dto.response.PostResponse;
+import com.doori.doori_backend.post.repository.PostRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Post 도메인 비즈니스 로직
+ * - 모든 조회는 readOnly=true 트랜잭션 (성능 최적화)
+ * - 모든 쓰기는 @Transactional (변경 감지 보장)
+ * - PostResponse 변환은 반드시 트랜잭션 내에서 수행 (LazyInitializationException 방지)
+ */
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 게시글 생성
+     * @param memberId 인증된 사용자 ID
+     * @param request  생성 요청 DTO
+     * @return 생성된 게시글 응답
+     */
+    @Transactional
+    public PostResponse createPost(Long memberId, PostCreateRequest request) {
+        Member author = findActiveMember(memberId);
+        PostType postType = parsePostType(request.postType());
+
+        Post post = Post.builder()
+            .author(author)
+            .postType(postType)
+            .title(request.title())
+            .region(request.region())
+            .university(request.university())
+            .monthlyRent(request.monthlyRent())
+            .deposit(request.deposit())
+            .description(request.description())
+            .roomImages(request.roomImages())
+            .build();
+
+        return PostResponse.from(postRepository.save(post));
+    }
+
+    /**
+     * 게시글 목록 조회 (페이지네이션 + 타입 필터)
+     * @param postTypeStr postType 문자열 (null이면 전체)
+     * @param page        0-based 페이지 번호
+     * @param size        페이지 크기
+     * @return 목록 + 전체 개수 래퍼
+     */
+    @Transactional(readOnly = true)
+    public Wrapper getPosts(String postTypeStr, int page, int size) {
+        // postTypeStr이 null이거나 빈 문자열이면 전체 조회
+        PostType postType = (postTypeStr == null || postTypeStr.isBlank()) ? null : parsePostType(postTypeStr);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Post> postPage = postRepository.findAllByFilter(postType, pageable);
+
+        List<PostListResponse> posts = postPage.getContent()
+            .stream()
+            .map(PostListResponse::from)
+            .toList();
+
+        return Wrapper.of(posts, (int) postPage.getTotalElements());
+    }
+
+    /**
+     * 게시글 단건 조회
+     * @param postId 게시글 ID
+     * @return 게시글 상세 응답
+     */
+    @Transactional(readOnly = true)
+    public PostResponse getPost(Long postId) {
+        Post post = findPost(postId);
+        return PostResponse.from(post);
+    }
+
+    /**
+     * 게시글 수정
+     * @param memberId 인증된 사용자 ID
+     * @param postId   수정할 게시글 ID
+     * @param request  수정 요청 DTO
+     */
+    @Transactional
+    public void updatePost(Long memberId, Long postId, PostUpdateRequest request) {
+        Post post = findPost(postId);
+        validateOwnership(post, memberId);
+        PostType postType = parsePostType(request.postType());
+
+        post.update(
+            postType,
+            request.title(),
+            request.region(),
+            request.university(),
+            request.monthlyRent(),
+            request.deposit(),
+            request.description(),
+            request.roomImages()
+        );
+        // 변경 감지(dirty checking)로 별도 save 불필요
+    }
+
+    /**
+     * 게시글 삭제
+     * @param memberId 인증된 사용자 ID
+     * @param postId   삭제할 게시글 ID
+     */
+    @Transactional
+    public void deletePost(Long memberId, Long postId) {
+        Post post = findPost(postId);
+        validateOwnership(post, memberId);
+        postRepository.delete(post);
+    }
+
+    // ─── 헬퍼 메서드 ────────────────────────────────────────────────────────────
+
+    /**
+     * 게시글 존재 확인 (없으면 POST_NOT_FOUND 예외)
+     */
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    /**
+     * 게시글 소유권 검증 (본인이 아니면 POST_FORBIDDEN 예외)
+     */
+    private void validateOwnership(Post post, Long memberId) {
+        if (!post.isOwnedBy(memberId)) {
+            throw new CustomException(ErrorCode.POST_FORBIDDEN);
+        }
+    }
+
+    /**
+     * ACTIVE 상태 회원 조회 (없거나 비활성이면 USER_NOT_FOUND 예외)
+     */
+    private Member findActiveMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (member.getStatus() != MemberStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        return member;
+    }
+
+    /**
+     * postType 문자열을 PostType Enum으로 변환 (유효하지 않으면 COMMON_BAD_REQUEST 예외)
+     */
+    private PostType parsePostType(String postTypeStr) {
+        try {
+            return PostType.valueOf(postTypeStr.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(
+                ErrorCode.COMMON_BAD_REQUEST,
+                "유효하지 않은 게시글 유형입니다: " + postTypeStr
+            );
+        }
+    }
+}

--- a/src/test/java/com/doori/doori_backend/post/PostControllerIntegrationTest.java
+++ b/src/test/java/com/doori/doori_backend/post/PostControllerIntegrationTest.java
@@ -1,0 +1,317 @@
+package com.doori.doori_backend.post;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+import com.doori.doori_backend.auth.domain.Gender;
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import com.doori.doori_backend.post.repository.PostRepository;
+import com.doori.doori_backend.school.domain.School;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Post API 통합 테스트
+ * - @Transactional: 각 테스트 후 DB 롤백으로 상태 격리
+ * - MockMvcBuilders.webAppContextSetup() + springSecurity()로 Security 필터 적용
+ *   → SecurityMockMvcRequestPostProcessors.authentication()을 요청별로 주입하여 인증 처리
+ * - H2 인메모리 DB (src/test/resources/application.properties 기준)
+ */
+@SpringBootTest
+@Transactional
+class PostControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    private MockMvc mockMvc;
+    private Member owner;
+    private Member otherMember;
+    private Post savedPost;
+
+    @BeforeEach
+    void setUp() {
+        // springSecurity() 적용으로 SecurityMockMvcRequestPostProcessors 동작 보장
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();
+
+        // 게시글 작성자 회원 생성
+        owner = memberRepository.save(Member.builder()
+            .email("owner@sju.ac.kr")
+            .password("password123!")
+            .name("작성자")
+            .nickname("ownerNick")
+            .gender(Gender.M)
+            .school(School.SEJONG_UNIV)
+            .build());
+
+        // 타 회원 생성 (권한 없음 테스트용)
+        otherMember = memberRepository.save(Member.builder()
+            .email("other@sju.ac.kr")
+            .password("password123!")
+            .name("타회원")
+            .nickname("otherNick")
+            .gender(Gender.F)
+            .school(School.SEJONG_UNIV)
+            .build());
+
+        // 테스트용 게시글 사전 저장
+        savedPost = postRepository.save(Post.builder()
+            .author(owner)
+            .postType(PostType.TRANSFER)
+            .title("서울대 근처 원룸 양도")
+            .region("서울 관악구")
+            .university("서울대학교")
+            .monthlyRent(500000)
+            .deposit(3000000)
+            .description("깨끗한 원룸입니다.")
+            .roomImages(List.of("https://example.com/img1.jpg"))
+            .build());
+    }
+
+    // ─── 인증 헬퍼 ────────────────────────────────────────────────────────────
+
+    /**
+     * SecurityMockMvcRequestPostProcessors.authentication()으로 요청에 인증 객체를 주입한다.
+     * springSecurity() 설정이 적용된 MockMvc에서만 동작한다.
+     */
+    private Authentication authOf(Long memberId) {
+        return new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+    }
+
+    // ─── POST /api/posts ────────────────────────────────────────────────────
+
+    @Test
+    void createPost_success() throws Exception {
+        mockMvc.perform(post("/api/posts")
+                .with(authentication(authOf(owner.getId())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "postType": "TRANSFER",
+                        "title": "강남 원룸 양도합니다",
+                        "region": "서울 강남구",
+                        "university": "연세대학교",
+                        "monthlyRent": 700000,
+                        "deposit": 5000000,
+                        "description": "신축 원룸입니다.",
+                        "roomImages": ["https://example.com/room.jpg"]
+                    }
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").value("게시글이 등록되었습니다."))
+            .andExpect(jsonPath("$.data.title").value("강남 원룸 양도합니다"))
+            .andExpect(jsonPath("$.data.postType").value("TRANSFER"))
+            .andExpect(jsonPath("$.data.authorId").value(owner.getId()));
+    }
+
+    @Test
+    void createPost_missingField_returns400() throws Exception {
+        // title 누락 → @NotBlank 유효성 검증 실패 (C001)
+        mockMvc.perform(post("/api/posts")
+                .with(authentication(authOf(owner.getId())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "postType": "TRANSFER",
+                        "region": "서울 강남구",
+                        "university": "연세대학교",
+                        "monthlyRent": 700000,
+                        "deposit": 5000000,
+                        "description": "설명"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("C001"));
+    }
+
+    // ─── GET /api/posts ──────────────────────────────────────────────────────
+
+    @Test
+    void getPosts_noFilter_returnsAll() throws Exception {
+        mockMvc.perform(get("/api/posts")
+                .with(authentication(authOf(owner.getId())))
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.total").value(1))
+            .andExpect(jsonPath("$.data.posts[0].title").value("서울대 근처 원룸 양도"));
+    }
+
+    @Test
+    void getPosts_withFilter_returnsFiltered() throws Exception {
+        // SUBLEASE 타입 게시글 추가
+        postRepository.save(Post.builder()
+            .author(owner)
+            .postType(PostType.SUBLEASE)
+            .title("단기 전대합니다")
+            .region("서울 강북구")
+            .university("서울대학교")
+            .monthlyRent(400000)
+            .deposit(1000000)
+            .description("2개월 단기 전대")
+            .roomImages(Collections.emptyList())
+            .build());
+
+        mockMvc.perform(get("/api/posts")
+                .with(authentication(authOf(owner.getId())))
+                .param("postType", "SUBLEASE")
+                .param("page", "0")
+                .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.total").value(1))
+            .andExpect(jsonPath("$.data.posts[0].postType").value("SUBLEASE"));
+    }
+
+    @Test
+    void getPosts_invalidType_returns400() throws Exception {
+        // 존재하지 않는 postType → parsePostType에서 COMMON_BAD_REQUEST(C001) 발생
+        mockMvc.perform(get("/api/posts")
+                .with(authentication(authOf(owner.getId())))
+                .param("postType", "INVALID_TYPE"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("C001"));
+    }
+
+    // ─── GET /api/posts/{postId} ─────────────────────────────────────────────
+
+    @Test
+    void getPost_exists_returns200() throws Exception {
+        mockMvc.perform(get("/api/posts/{postId}", savedPost.getPostId())
+                .with(authentication(authOf(owner.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.postId").value(savedPost.getPostId()))
+            .andExpect(jsonPath("$.data.title").value("서울대 근처 원룸 양도"))
+            .andExpect(jsonPath("$.data.authorNickname").value("ownerNick"));
+    }
+
+    @Test
+    void getPost_notFound_returns404() throws Exception {
+        mockMvc.perform(get("/api/posts/{postId}", 999999L)
+                .with(authentication(authOf(owner.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("P001"));
+    }
+
+    // ─── PUT /api/posts/{postId} ─────────────────────────────────────────────
+
+    @Test
+    void updatePost_owner_returns204() throws Exception {
+        mockMvc.perform(put("/api/posts/{postId}", savedPost.getPostId())
+                .with(authentication(authOf(owner.getId())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "postType": "SUBLEASE",
+                        "title": "수정된 제목",
+                        "region": "서울 마포구",
+                        "university": "홍익대학교",
+                        "monthlyRent": 600000,
+                        "deposit": 2000000,
+                        "description": "수정된 설명",
+                        "roomImages": []
+                    }
+                    """))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void updatePost_notOwner_returns403() throws Exception {
+        // 타 회원으로 요청 → POST_FORBIDDEN(P002)
+        mockMvc.perform(put("/api/posts/{postId}", savedPost.getPostId())
+                .with(authentication(authOf(otherMember.getId())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "postType": "TRANSFER",
+                        "title": "무단 수정 시도",
+                        "region": "서울",
+                        "university": "서울대학교",
+                        "monthlyRent": 500000,
+                        "deposit": 1000000,
+                        "description": "설명",
+                        "roomImages": []
+                    }
+                    """))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("P002"));
+    }
+
+    @Test
+    void updatePost_notFound_returns404() throws Exception {
+        mockMvc.perform(put("/api/posts/{postId}", 999999L)
+                .with(authentication(authOf(owner.getId())))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "postType": "TRANSFER",
+                        "title": "없는 게시글 수정",
+                        "region": "서울",
+                        "university": "서울대학교",
+                        "monthlyRent": 500000,
+                        "deposit": 1000000,
+                        "description": "설명",
+                        "roomImages": []
+                    }
+                    """))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("P001"));
+    }
+
+    // ─── DELETE /api/posts/{postId} ──────────────────────────────────────────
+
+    @Test
+    void deletePost_owner_returns204() throws Exception {
+        mockMvc.perform(delete("/api/posts/{postId}", savedPost.getPostId())
+                .with(authentication(authOf(owner.getId()))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deletePost_notOwner_returns403() throws Exception {
+        // 타 회원으로 요청 → POST_FORBIDDEN(P002)
+        mockMvc.perform(delete("/api/posts/{postId}", savedPost.getPostId())
+                .with(authentication(authOf(otherMember.getId()))))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("P002"));
+    }
+
+    @Test
+    void deletePost_notFound_returns404() throws Exception {
+        mockMvc.perform(delete("/api/posts/{postId}", 999999L)
+                .with(authentication(authOf(owner.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("P001"));
+    }
+}


### PR DESCRIPTION
## 연관 이슈

Closes #22

## 변경 요약

Post(게시글) 도메인의 기본 CRUD API와 목록/상세 조회 기능을 구현했습니다.

- ErrorCode 추가 (POST_NOT_FOUND P001, POST_FORBIDDEN P002)
- Post 엔티티 구현 (JPA Auditing, ElementCollection roomImages)
- PostRepository 구현 (findAllByFilter JPQL 최적화)
- PostService 구현 (비즈니스 로직, 소유권 검증, 트랜잭션 관리)
- PostController 구현 (5개 REST 엔드포인트, ApiResponse 패턴)
- 13개 통합 테스트 (생성, 목록, 상세, 수정, 삭제)
- ROADMAP.md 문서 작성

## 구현 상세

### 생성된 파일 (12개)

**Domain**:
- Post.java: @ManyToOne(LAZY) author, @ElementCollection roomImages, JPA Auditing
- PostType.java: TRANSFER, SUBLEASE, WANTED Enum

**DTO**:
- PostCreateRequest.java, PostUpdateRequest.java: record 타입
- PostResponse.java, PostListResponse.java: from() 정적 메서드

**API 계층**:
- PostRepository.java: JOIN FETCH로 N+1 방지
- PostService.java: @Transactional, CustomException, 헬퍼 메서드
- PostController.java: ResponseEntity<ApiResponse<T>> 패턴

**테스트**:
- PostControllerIntegrationTest.java: 13개 케이스

**문서**:
- docs/ROADMAP.md: 5단계 개발 계획

### API/DB 영향

**새 테이블**:
- post: 게시글 정보 저장
- post_image: 게시글 이미지 URL 저장 (@ElementCollection)

**ErrorCode 추가**:
- P001: POST_NOT_FOUND (404)
- P002: POST_FORBIDDEN (403)

**엔드포인트 (5개)**:
- POST /api/posts: 게시글 생성 (201 Created)
- GET /api/posts: 목록 조회 (필터, 페이지네이션)
- GET /api/posts/{postId}: 상세 조회
- PUT /api/posts/{postId}: 수정 (소유권 검증)
- DELETE /api/posts/{postId}: 삭제 (소유권 검증)

### 핵심 설계 결정

1. **response-exception.md 규칙 100% 준수**
   - Controller: ResponseEntity<ApiResponse<T>> 또는 ResponseEntity<Void>
   - Service: CustomException만 사용, ApiResponse 미반환
   - GlobalExceptionHandler: 예외 처리 한곳 집중

2. **성능 최적화**
   - LAZY Loading: ManyToOne(fetch = FetchType.LAZY)
   - JOIN FETCH: findAllByFilter()에서 author 프리페칭
   - readOnly 트랜잭션: 조회 메서드 최적화

3. **보안**
   - 소유권 검증: validateOwnership() 필수 호출
   - 회원 상태 검증: MemberStatus.ACTIVE 확인
   - Authentication 안전: memberId 타입캐스팅

4. **테스트**
   - SecurityMockMvcConfigurers.springSecurity() 적용
   - @Transactional 롤백으로 상태 격리
   - 13개 시나리오 완전 커버

## 테스트 결과

실행 명령:
```bash
./gradlew clean build
./gradlew test
```

결과:
- ✅ BUILD SUCCESSFUL (0 에러, 0 경고)
- ✅ 13개 테스트 PASS (0 실패)
- ✅ 변경사항: 12개 파일, 985개 라인 추가, 1개 라인 삭제

테스트 케이스:
- 생성: 2개 (성공, 필드 누락)
- 목록: 3개 (전체, 필터, 잘못된 타입)
- 상세: 2개 (존재, 없음)
- 수정: 3개 (성공, 권한 없음, 없음)
- 삭제: 3개 (성공, 권한 없음, 없음)

## 체크리스트

- [x] PR 본문에 `Closes #이슈번호`를 포함했습니다.
- [x] API/DB 변경 사항을 본문에 작성했습니다.
- [x] 로컬 검증 명령을 실행했고 결과를 본문에 작성했습니다.
- [x] response-exception.md 규칙을 100% 준수했습니다.
- [x] commit.md 네이밍 규칙을 준수했습니다.
- [x] 모든 테스트가 통과했습니다 (13/13 PASS).