### PR TITLE
[✨ Feat] 찜(Favorite) 기능 구현 (유저/게시글 CRUD) (#24)

### DIFF
--- a/src/main/java/com/doori/doori_backend/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/doori/doori_backend/favorite/controller/FavoriteController.java
@@ -1,0 +1,116 @@
+package com.doori.doori_backend.favorite.controller;
+
+import com.doori.doori_backend.favorite.dto.response.FavoritePostResponse;
+import com.doori.doori_backend.favorite.dto.response.FavoriteUserResponse;
+import com.doori.doori_backend.favorite.service.FavoriteService;
+import com.doori.doori_backend.global.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 찜(Favorite) API 컨트롤러
+ * - 모든 엔드포인트는 JWT 인증 필요 (SecurityConfig에서 anyRequest().authenticated() 적용)
+ * - Authentication.getPrincipal()로 memberId(Long) 추출
+ * - 예외 처리는 GlobalExceptionHandler에 위임, Controller는 try-catch 없음
+ */
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    // ─── 유저 찜 엔드포인트 ──────────────────────────────────────────────────
+
+    /**
+     * 유저 찜 추가
+     * POST /api/users/{userId}/favorites → 204 No Content
+     */
+    @PostMapping("/users/{userId}/favorites")
+    public ResponseEntity<Void> addUserFavorite(
+        @PathVariable Long userId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        favoriteService.addUserFavorite(memberId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 유저 찜 삭제
+     * DELETE /api/users/{userId}/favorites → 204 No Content
+     */
+    @DeleteMapping("/users/{userId}/favorites")
+    public ResponseEntity<Void> removeUserFavorite(
+        @PathVariable Long userId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        favoriteService.removeUserFavorite(memberId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 내 찜 유저 목록 조회
+     * GET /api/users/favorites → 200 OK + List
+     */
+    @GetMapping("/users/favorites")
+    public ResponseEntity<ApiResponse<List<FavoriteUserResponse>>> getFavoriteUsers(
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        List<FavoriteUserResponse> response = favoriteService.getFavoriteUsers(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ─── 게시글 찜 엔드포인트 ────────────────────────────────────────────────
+
+    /**
+     * 게시글 찜 추가
+     * POST /api/posts/{postId}/favorites → 204 No Content
+     */
+    @PostMapping("/posts/{postId}/favorites")
+    public ResponseEntity<Void> addPostFavorite(
+        @PathVariable Long postId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        favoriteService.addPostFavorite(memberId, postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 게시글 찜 삭제
+     * DELETE /api/posts/{postId}/favorites → 204 No Content
+     */
+    @DeleteMapping("/posts/{postId}/favorites")
+    public ResponseEntity<Void> removePostFavorite(
+        @PathVariable Long postId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        favoriteService.removePostFavorite(memberId, postId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 내 찜 게시글 목록 조회
+     * GET /api/posts/favorites → 200 OK + List
+     */
+    @GetMapping("/posts/favorites")
+    public ResponseEntity<ApiResponse<List<FavoritePostResponse>>> getFavoritePosts(
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        List<FavoritePostResponse> response = favoriteService.getFavoritePosts(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/doori/doori_backend/favorite/domain/PostFavorite.java
+++ b/src/main/java/com/doori/doori_backend/favorite/domain/PostFavorite.java
@@ -1,0 +1,66 @@
+package com.doori.doori_backend.favorite.domain;
+
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.post.domain.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 게시글 찜 엔티티
+ * - member: 찜을 누른 사용자 (주체)
+ * - post: 찜 대상 게시글
+ * - (member_id, post_id) 복합 유니크 제약으로 중복 찜을 DB 레벨에서 방지
+ */
+@Entity
+@Table(
+    name = "post_favorite",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_post_favorite",
+        columnNames = {"member_id", "post_id"}
+    )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class PostFavorite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 찜을 누른 사용자 — LAZY 로딩
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 찜 대상 게시글 — LAZY 로딩
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PostFavorite(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/favorite/domain/UserFavorite.java
+++ b/src/main/java/com/doori/doori_backend/favorite/domain/UserFavorite.java
@@ -1,0 +1,66 @@
+package com.doori.doori_backend.favorite.domain;
+
+import com.doori.doori_backend.auth.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 유저 찜 엔티티
+ * - member: 찜을 누른 사용자 (주체)
+ * - target: 찜 대상 사용자
+ * - (member_id, target_id) 복합 유니크 제약으로 중복 찜을 DB 레벨에서 방지
+ * - 자기 자신 찜 방지는 Service 레이어에서 검증
+ */
+@Entity
+@Table(
+    name = "user_favorite",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_user_favorite",
+        columnNames = {"member_id", "target_id"}
+    )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserFavorite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 찜을 누른 사용자 — LAZY 로딩
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    // 찜 대상 사용자 — LAZY 로딩
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", nullable = false)
+    private Member target;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserFavorite(Member member, Member target) {
+        this.member = member;
+        this.target = target;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/favorite/dto/response/FavoritePostResponse.java
+++ b/src/main/java/com/doori/doori_backend/favorite/dto/response/FavoritePostResponse.java
@@ -1,0 +1,49 @@
+package com.doori.doori_backend.favorite.dto.response;
+
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import java.time.LocalDateTime;
+
+/**
+ * 찜한 게시글 목록 응답 DTO
+ * - 목록 수준의 게시글 정보만 노출 (description, roomImages 전체 목록 제외)
+ * - thumbnailImageUrl: roomImages 첫 번째 이미지, 없으면 null
+ */
+public record FavoritePostResponse(
+    Long postId,
+    PostType postType,
+    String title,
+    String region,
+    String university,
+    Integer monthlyRent,
+    Integer deposit,
+    String thumbnailImageUrl,
+    Long authorId,
+    String authorNickname,
+    LocalDateTime createdAt
+) {
+
+    /**
+     * Post 엔티티를 FavoritePostResponse 로 변환한다.
+     * roomImages는 @ElementCollection이므로 트랜잭션 내에서 호출해야 한다.
+     */
+    public static FavoritePostResponse from(Post post) {
+        String thumbnail = post.getRoomImages().isEmpty()
+            ? null
+            : post.getRoomImages().get(0);
+
+        return new FavoritePostResponse(
+            post.getPostId(),
+            post.getPostType(),
+            post.getTitle(),
+            post.getRegion(),
+            post.getUniversity(),
+            post.getMonthlyRent(),
+            post.getDeposit(),
+            thumbnail,
+            post.getAuthor().getId(),
+            post.getAuthor().getNickname(),
+            post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/favorite/dto/response/FavoriteUserResponse.java
+++ b/src/main/java/com/doori/doori_backend/favorite/dto/response/FavoriteUserResponse.java
@@ -1,0 +1,29 @@
+package com.doori.doori_backend.favorite.dto.response;
+
+import com.doori.doori_backend.auth.domain.Member;
+
+/**
+ * 찜한 유저 목록 응답 DTO
+ * - 찜 대상 사용자의 기본 프로필 정보만 노출
+ */
+public record FavoriteUserResponse(
+    Long userId,
+    String nickname,
+    String gender,
+    String schoolName,
+    String profileImageUrl
+) {
+
+    /**
+     * Member 엔티티를 FavoriteUserResponse 로 변환한다.
+     */
+    public static FavoriteUserResponse from(Member member) {
+        return new FavoriteUserResponse(
+            member.getId(),
+            member.getNickname(),
+            member.getGender().name(),
+            member.getSchool().getDisplayName(),
+            member.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/favorite/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/doori/doori_backend/favorite/repository/PostFavoriteRepository.java
@@ -1,0 +1,37 @@
+package com.doori.doori_backend.favorite.repository;
+
+import com.doori.doori_backend.favorite.domain.PostFavorite;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostFavoriteRepository extends JpaRepository<PostFavorite, Long> {
+
+    /**
+     * 특정 사용자가 특정 게시글을 찜했는지 확인
+     */
+    @Query("SELECT COUNT(pf) > 0 FROM PostFavorite pf WHERE pf.member.id = :memberId AND pf.post.postId = :postId")
+    boolean existsByMemberAndPost(@Param("memberId") Long memberId, @Param("postId") Long postId);
+
+    /**
+     * 특정 사용자가 특정 게시글에 대해 등록한 찜 조회 (삭제 시 사용)
+     */
+    @Query("SELECT pf FROM PostFavorite pf WHERE pf.member.id = :memberId AND pf.post.postId = :postId")
+    Optional<PostFavorite> findByMemberAndPost(@Param("memberId") Long memberId, @Param("postId") Long postId);
+
+    /**
+     * 특정 사용자가 찜한 게시글 목록 조회
+     * - post, post.author, post.roomImages를 fetch join하여 N+1 방지
+     */
+    @Query("""
+        SELECT pf FROM PostFavorite pf
+        JOIN FETCH pf.post p
+        JOIN FETCH p.author
+        LEFT JOIN FETCH p.roomImages
+        WHERE pf.member.id = :memberId
+        ORDER BY pf.createdAt DESC
+        """)
+    List<PostFavorite> findAllByMemberIdWithPost(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/doori/doori_backend/favorite/repository/UserFavoriteRepository.java
+++ b/src/main/java/com/doori/doori_backend/favorite/repository/UserFavoriteRepository.java
@@ -1,0 +1,33 @@
+package com.doori.doori_backend.favorite.repository;
+
+import com.doori.doori_backend.favorite.domain.UserFavorite;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserFavoriteRepository extends JpaRepository<UserFavorite, Long> {
+
+    /**
+     * 특정 사용자가 특정 대상을 찜했는지 확인
+     */
+    boolean existsByMemberIdAndTargetId(Long memberId, Long targetId);
+
+    /**
+     * 특정 사용자가 특정 대상에 대해 등록한 찜 조회 (삭제 시 사용)
+     */
+    Optional<UserFavorite> findByMemberIdAndTargetId(Long memberId, Long targetId);
+
+    /**
+     * 특정 사용자가 찜한 유저 목록 조회
+     * - target을 fetch join하여 N+1 방지
+     */
+    @Query("""
+        SELECT uf FROM UserFavorite uf
+        JOIN FETCH uf.target
+        WHERE uf.member.id = :memberId
+        ORDER BY uf.createdAt DESC
+        """)
+    List<UserFavorite> findAllByMemberIdWithTarget(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/doori/doori_backend/favorite/service/FavoriteService.java
+++ b/src/main/java/com/doori/doori_backend/favorite/service/FavoriteService.java
@@ -1,0 +1,164 @@
+package com.doori.doori_backend.favorite.service;
+
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.auth.domain.MemberStatus;
+import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.favorite.domain.PostFavorite;
+import com.doori.doori_backend.favorite.domain.UserFavorite;
+import com.doori.doori_backend.favorite.dto.response.FavoritePostResponse;
+import com.doori.doori_backend.favorite.dto.response.FavoriteUserResponse;
+import com.doori.doori_backend.favorite.repository.PostFavoriteRepository;
+import com.doori.doori_backend.favorite.repository.UserFavoriteRepository;
+import com.doori.doori_backend.global.error.ErrorCode;
+import com.doori.doori_backend.global.exception.CustomException;
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.repository.PostRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 찜(Favorite) 도메인 비즈니스 로직
+ * - 모든 조회는 readOnly=true 트랜잭션 (성능 최적화)
+ * - 모든 쓰기는 @Transactional (변경 감지 보장)
+ * - ApiResponse, ErrorResponse 반환 금지 — 예외는 CustomException으로만 처리
+ */
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final UserFavoriteRepository userFavoriteRepository;
+    private final PostFavoriteRepository postFavoriteRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    // ─── 유저 찜 ─────────────────────────────────────────────────────────────
+
+    /**
+     * 유저 찜 추가
+     * @param memberId 인증된 사용자 ID (찜하는 주체)
+     * @param targetId 찜 대상 사용자 ID
+     */
+    @Transactional
+    public void addUserFavorite(Long memberId, Long targetId) {
+        // 자기 자신 찜 불가
+        if (memberId.equals(targetId)) {
+            throw new CustomException(ErrorCode.COMMON_BAD_REQUEST, "자기 자신을 찜할 수 없습니다.");
+        }
+
+        // 중복 찜 방지 (DB 조회 전에 먼저 확인)
+        if (userFavoriteRepository.existsByMemberIdAndTargetId(memberId, targetId)) {
+            throw new CustomException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+
+        Member member = findActiveMember(memberId);
+        Member target = findActiveMember(targetId);
+
+        userFavoriteRepository.save(UserFavorite.builder()
+            .member(member)
+            .target(target)
+            .build());
+    }
+
+    /**
+     * 유저 찜 삭제
+     * @param memberId 인증된 사용자 ID
+     * @param targetId 찜 대상 사용자 ID
+     */
+    @Transactional
+    public void removeUserFavorite(Long memberId, Long targetId) {
+        UserFavorite userFavorite = userFavoriteRepository
+            .findByMemberIdAndTargetId(memberId, targetId)
+            .orElseThrow(() -> new CustomException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        userFavoriteRepository.delete(userFavorite);
+    }
+
+    /**
+     * 내 찜 유저 목록 조회
+     * @param memberId 인증된 사용자 ID
+     * @return 찜한 유저 응답 목록
+     */
+    @Transactional(readOnly = true)
+    public List<FavoriteUserResponse> getFavoriteUsers(Long memberId) {
+        return userFavoriteRepository.findAllByMemberIdWithTarget(memberId)
+            .stream()
+            .map(uf -> FavoriteUserResponse.from(uf.getTarget()))
+            .toList();
+    }
+
+    // ─── 게시글 찜 ───────────────────────────────────────────────────────────
+
+    /**
+     * 게시글 찜 추가
+     * @param memberId 인증된 사용자 ID
+     * @param postId   찜 대상 게시글 ID
+     */
+    @Transactional
+    public void addPostFavorite(Long memberId, Long postId) {
+        // 중복 찜 방지 (DB 조회 전에 먼저 확인)
+        if (postFavoriteRepository.existsByMemberAndPost(memberId, postId)) {
+            throw new CustomException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+
+        Member member = findActiveMember(memberId);
+        Post post = findPost(postId);
+
+        postFavoriteRepository.save(PostFavorite.builder()
+            .member(member)
+            .post(post)
+            .build());
+    }
+
+    /**
+     * 게시글 찜 삭제
+     * @param memberId 인증된 사용자 ID
+     * @param postId   찜 대상 게시글 ID
+     */
+    @Transactional
+    public void removePostFavorite(Long memberId, Long postId) {
+        PostFavorite postFavorite = postFavoriteRepository
+            .findByMemberAndPost(memberId, postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.FAVORITE_NOT_FOUND));
+
+        postFavoriteRepository.delete(postFavorite);
+    }
+
+    /**
+     * 내 찜 게시글 목록 조회
+     * - post와 post.author를 fetch join하여 N+1 방지
+     * - roomImages(@ElementCollection) 접근은 트랜잭션 내에서 수행
+     * @param memberId 인증된 사용자 ID
+     * @return 찜한 게시글 응답 목록
+     */
+    @Transactional(readOnly = true)
+    public List<FavoritePostResponse> getFavoritePosts(Long memberId) {
+        return postFavoriteRepository.findAllByMemberIdWithPost(memberId)
+            .stream()
+            .map(pf -> FavoritePostResponse.from(pf.getPost()))
+            .toList();
+    }
+
+    // ─── 헬퍼 메서드 ─────────────────────────────────────────────────────────
+
+    /**
+     * ACTIVE 상태 회원 조회 (없거나 비활성이면 USER_NOT_FOUND 예외)
+     */
+    private Member findActiveMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (member.getStatus() != MemberStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        return member;
+    }
+
+    /**
+     * 게시글 존재 확인 (없으면 POST_NOT_FOUND 예외)
+     */
+    private Post findPost(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
 	USER_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "U002", "이미 사용 중인 닉네임입니다."),
 	USER_LIFESTYLE_PROFILE_REQUIRED(HttpStatus.BAD_REQUEST, "U003", "생활 상황 프로필을 먼저 완성해주세요."),
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "게시글을 찾을 수 없습니다."),
-	POST_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "게시글에 대한 접근 권한이 없습니다.");
+	POST_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "게시글에 대한 접근 권한이 없습니다."),
+	FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "F001", "이미 찜한 항목입니다."),
+	FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "찜 내역을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/test/java/com/doori/doori_backend/favorite/FavoriteApiTest.java
+++ b/src/test/java/com/doori/doori_backend/favorite/FavoriteApiTest.java
@@ -1,0 +1,285 @@
+package com.doori.doori_backend.favorite;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.doori.doori_backend.auth.domain.Gender;
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.favorite.domain.PostFavorite;
+import com.doori.doori_backend.favorite.domain.UserFavorite;
+import com.doori.doori_backend.favorite.repository.PostFavoriteRepository;
+import com.doori.doori_backend.favorite.repository.UserFavoriteRepository;
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import com.doori.doori_backend.post.repository.PostRepository;
+import com.doori.doori_backend.school.domain.School;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * 찜(Favorite) API 통합 테스트
+ * - @Transactional: 각 테스트 후 DB 롤백으로 상태 격리
+ * - MockMvcBuilders.webAppContextSetup() + springSecurity()로 Security 필터 적용
+ *   → SecurityMockMvcRequestPostProcessors.authentication()을 요청별로 주입하여 인증 처리
+ * - H2 인메모리 DB (src/test/resources/application.properties 기준)
+ */
+@SpringBootTest
+@Transactional
+class FavoriteApiTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserFavoriteRepository userFavoriteRepository;
+
+    @Autowired
+    private PostFavoriteRepository postFavoriteRepository;
+
+    private MockMvc mockMvc;
+
+    private Member me;
+    private Member targetUser;
+    private Post savedPost;
+
+    @BeforeEach
+    void setUp() {
+        // springSecurity() 적용으로 SecurityMockMvcRequestPostProcessors 동작 보장
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();
+
+        // 요청 주체 회원 생성
+        me = memberRepository.save(Member.builder()
+            .email("me@sju.ac.kr")
+            .password("password123!")
+            .name("나")
+            .nickname("meNick")
+            .gender(Gender.M)
+            .school(School.SEJONG_UNIV)
+            .build());
+
+        // 찜 대상 회원 생성
+        targetUser = memberRepository.save(Member.builder()
+            .email("target@sju.ac.kr")
+            .password("password123!")
+            .name("대상")
+            .nickname("targetNick")
+            .gender(Gender.F)
+            .school(School.SEJONG_UNIV)
+            .build());
+
+        // 찜 대상 게시글 생성
+        savedPost = postRepository.save(Post.builder()
+            .author(targetUser)
+            .postType(PostType.TRANSFER)
+            .title("원룸 양도합니다")
+            .region("서울 관악구")
+            .university("서울대학교")
+            .monthlyRent(500000)
+            .deposit(3000000)
+            .description("깨끗한 원룸입니다.")
+            .roomImages(List.of("https://example.com/img1.jpg"))
+            .build());
+    }
+
+    // ─── 인증 헬퍼 ────────────────────────────────────────────────────────────
+
+    /**
+     * SecurityMockMvcRequestPostProcessors.authentication()으로 요청에 인증 객체를 주입한다.
+     * springSecurity() 설정이 적용된 MockMvc에서만 동작한다.
+     */
+    private Authentication authOf(Long memberId) {
+        return new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+    }
+
+    // ─── 유저 찜 추가 ────────────────────────────────────────────────────────
+
+    @Test
+    void addUserFavorite_success() throws Exception {
+        mockMvc.perform(post("/api/users/{userId}/favorites", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void addUserFavorite_duplicate_returns409() throws Exception {
+        // 이미 찜된 상태 사전 세팅
+        userFavoriteRepository.save(UserFavorite.builder()
+            .member(me)
+            .target(targetUser)
+            .build());
+
+        mockMvc.perform(post("/api/users/{userId}/favorites", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("F001"));
+    }
+
+    @Test
+    void addUserFavorite_selfFavorite_returns400() throws Exception {
+        // 자기 자신 찜 시도 → C001
+        mockMvc.perform(post("/api/users/{userId}/favorites", me.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("C001"));
+    }
+
+    @Test
+    void addUserFavorite_targetNotFound_returns404() throws Exception {
+        mockMvc.perform(post("/api/users/{userId}/favorites", 999999L)
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("U001"));
+    }
+
+    // ─── 유저 찜 삭제 ────────────────────────────────────────────────────────
+
+    @Test
+    void removeUserFavorite_success() throws Exception {
+        // 사전에 찜 등록
+        userFavoriteRepository.save(UserFavorite.builder()
+            .member(me)
+            .target(targetUser)
+            .build());
+
+        mockMvc.perform(delete("/api/users/{userId}/favorites", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void removeUserFavorite_notFound_returns404() throws Exception {
+        // 찜하지 않은 대상 삭제 시도 → F002
+        mockMvc.perform(delete("/api/users/{userId}/favorites", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("F002"));
+    }
+
+    // ─── 내 찜 유저 목록 조회 ─────────────────────────────────────────────────
+
+    @Test
+    void getFavoriteUsers_success() throws Exception {
+        // 사전에 찜 등록
+        userFavoriteRepository.save(UserFavorite.builder()
+            .member(me)
+            .target(targetUser)
+            .build());
+
+        mockMvc.perform(get("/api/users/favorites")
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data[0].userId").value(targetUser.getId()))
+            .andExpect(jsonPath("$.data[0].nickname").value("targetNick"));
+    }
+
+    @Test
+    void getFavoriteUsers_empty_returnsEmptyList() throws Exception {
+        mockMvc.perform(get("/api/users/favorites")
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    // ─── 게시글 찜 추가 ──────────────────────────────────────────────────────
+
+    @Test
+    void addPostFavorite_success() throws Exception {
+        mockMvc.perform(post("/api/posts/{postId}/favorites", savedPost.getPostId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void addPostFavorite_duplicate_returns409() throws Exception {
+        // 이미 찜된 상태 사전 세팅
+        postFavoriteRepository.save(PostFavorite.builder()
+            .member(me)
+            .post(savedPost)
+            .build());
+
+        mockMvc.perform(post("/api/posts/{postId}/favorites", savedPost.getPostId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("F001"));
+    }
+
+    @Test
+    void addPostFavorite_postNotFound_returns404() throws Exception {
+        // 존재하지 않는 게시글 찜 → P001
+        mockMvc.perform(post("/api/posts/{postId}/favorites", 999999L)
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("P001"));
+    }
+
+    // ─── 게시글 찜 삭제 ──────────────────────────────────────────────────────
+
+    @Test
+    void removePostFavorite_success() throws Exception {
+        // 사전에 찜 등록
+        postFavoriteRepository.save(PostFavorite.builder()
+            .member(me)
+            .post(savedPost)
+            .build());
+
+        mockMvc.perform(delete("/api/posts/{postId}/favorites", savedPost.getPostId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void removePostFavorite_notFound_returns404() throws Exception {
+        // 찜하지 않은 게시글 삭제 시도 → F002
+        mockMvc.perform(delete("/api/posts/{postId}/favorites", savedPost.getPostId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("F002"));
+    }
+
+    // ─── 내 찜 게시글 목록 조회 ───────────────────────────────────────────────
+
+    @Test
+    void getFavoritePosts_success() throws Exception {
+        // 사전에 찜 등록
+        postFavoriteRepository.save(PostFavorite.builder()
+            .member(me)
+            .post(savedPost)
+            .build());
+
+        mockMvc.perform(get("/api/posts/favorites")
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data[0].postId").value(savedPost.getPostId()))
+            .andExpect(jsonPath("$.data[0].title").value("원룸 양도합니다"))
+            .andExpect(jsonPath("$.data[0].postType").value("TRANSFER"));
+    }
+}


### PR DESCRIPTION
## 연관 이슈

Closes #24

## 변경 요약

- 유저/게시글에 대한 단방향 찜(Favorite) CRUD API 구현
- 신규 도메인 `favorite` 패키지 추가 (엔티티, 리포지토리, 서비스, 컨트롤러, DTO)
- `ErrorCode` F001(FAVORITE_ALREADY_EXISTS), F002(FAVORITE_NOT_FOUND) 추가

## 구현 상세

### 신규 엔티티 (DB 영향)
- `UserFavorite` 테이블: `(member_id, target_id)` 복합 유니크 제약
- `PostFavorite` 테이블: `(member_id, post_id)` 복합 유니크 제약

### API 엔드포인트 (6개)

| Method | URL | 응답 |
|--------|-----|------|
| POST | `/api/users/{userId}/favorites` | 204 No Content |
| DELETE | `/api/users/{userId}/favorites` | 204 No Content |
| GET | `/api/users/favorites` | 200 OK |
| POST | `/api/posts/{postId}/favorites` | 204 No Content |
| DELETE | `/api/posts/{postId}/favorites` | 204 No Content |
| GET | `/api/posts/favorites` | 200 OK |

### 예외 처리

- 자기 자신 찜 → `C001` (400)
- 중복 찜 → `F001` (409)
- 찜 내역 없이 삭제 → `F002` (404)
- 대상 유저 없음 → `U001` (404)
- 대상 게시글 없음 → `P001` (404)

### N+1 방지

- `findAllByMemberIdWithTarget`: `JOIN FETCH uf.target`
- `findAllByMemberIdWithPost`: `JOIN FETCH p.author LEFT JOIN FETCH p.roomImages`

## 테스트 결과

- 실행 명령어: `./gradlew clean test`
- 결과 요약: BUILD SUCCESSFUL — 전체 테스트 통과 (통합 테스트 13개 케이스 포함)

## 체크리스트

- [x] PR 본문에 `Closes #24` 포함
- [x] 주요 구현 내용(API/DB 변경 사항) 본문에 작성
- [x] 로컬 검증 명령 실행 및 결과 본문에 작성