### PR TITLE
Feat/26 notification api

### DIFF
--- a/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "게시글을 찾을 수 없습니다."),
 	POST_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "게시글에 대한 접근 권한이 없습니다."),
 	FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "F001", "이미 찜한 항목입니다."),
-	FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "찜 내역을 찾을 수 없습니다.");
+	FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "찜 내역을 찾을 수 없습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "존재하지 않는 알림입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
@@ -30,19 +30,19 @@ public class NotificationController {
     }
 
     @PutMapping("/{notificationId}/read")
-    public ResponseEntity<ApiResponse<Void>> markAsRead(
+    public ResponseEntity<Void> markAsRead(
         @PathVariable Long notificationId,
         Authentication authentication
     ) {
         Long memberId = (Long) authentication.getPrincipal();
         notificationService.markAsRead(memberId, notificationId);
-        return ResponseEntity.ok(ApiResponse.success("읽음 처리되었습니다.", null));
+        return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/read-all")
-    public ResponseEntity<ApiResponse<Void>> markAllAsRead(Authentication authentication) {
+    public ResponseEntity<Void> markAllAsRead(Authentication authentication) {
         Long memberId = (Long) authentication.getPrincipal();
         notificationService.markAllAsRead(memberId);
-        return ResponseEntity.ok(ApiResponse.success("모든 알림을 읽음 처리했습니다.", null));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
@@ -1,0 +1,48 @@
+package com.doori.doori_backend.notification.controller;
+
+import com.doori.doori_backend.global.response.ApiResponse;
+import com.doori.doori_backend.notification.dto.response.NotificationListResponse;
+import com.doori.doori_backend.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
+        @RequestParam(required = false) String cursor,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(notificationService.getNotifications(memberId, cursor)));
+    }
+
+    @PutMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+        @PathVariable Long notificationId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        notificationService.markAsRead(memberId, notificationId);
+        return ResponseEntity.ok(ApiResponse.success("읽음 처리되었습니다.", null));
+    }
+
+    @PutMapping("/read-all")
+    public ResponseEntity<ApiResponse<Void>> markAllAsRead(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        notificationService.markAllAsRead(memberId);
+        return ResponseEntity.ok(ApiResponse.success("모든 알림을 읽음 처리했습니다.", null));
+    }
+}

--- a/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
@@ -1,0 +1,77 @@
+package com.doori.doori_backend.notification.domain;
+
+import com.doori.doori_backend.auth.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isRead;
+
+    private Long referenceId;
+
+    private String referenceType;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime readAt;
+
+    @Builder
+    public Notification(Member receiver, NotificationType type, String title, String content,
+        Long referenceId, String referenceType) {
+        this.receiver = receiver;
+        this.type = type;
+        this.title = title;
+        this.content = content;
+        this.referenceId = referenceId;
+        this.referenceType = referenceType;
+        this.isRead = false;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
@@ -45,7 +45,7 @@ public class Notification {
 
     private String content;
 
-    @Column(nullable = false)
+    @Column(name = "is_read", nullable = false)
     private boolean isRead;
 
     private Long referenceId;
@@ -71,6 +71,9 @@ public class Notification {
     }
 
     public void markAsRead() {
+        if (this.isRead) {
+            return;
+        }
         this.isRead = true;
         this.readAt = LocalDateTime.now();
     }

--- a/src/main/java/com/doori/doori_backend/notification/domain/NotificationType.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/NotificationType.java
@@ -1,0 +1,8 @@
+package com.doori.doori_backend.notification.domain;
+
+public enum NotificationType {
+    MATCH,
+    CHAT,
+    COMMUNITY,
+    SYSTEM
+}

--- a/src/main/java/com/doori/doori_backend/notification/dto/response/NotificationItem.java
+++ b/src/main/java/com/doori/doori_backend/notification/dto/response/NotificationItem.java
@@ -1,0 +1,30 @@
+package com.doori.doori_backend.notification.dto.response;
+
+import com.doori.doori_backend.notification.domain.Notification;
+import java.time.LocalDateTime;
+
+public record NotificationItem(
+    Long notificationId,
+    String type,
+    String title,
+    String content,
+    boolean isRead,
+    Long referenceId,
+    String referenceType,
+    LocalDateTime createdAt,
+    LocalDateTime readAt
+) {
+    public static NotificationItem from(Notification notification) {
+        return new NotificationItem(
+            notification.getId(),
+            notification.getType().name().toLowerCase(),
+            notification.getTitle(),
+            notification.getContent(),
+            notification.isRead(),
+            notification.getReferenceId(),
+            notification.getReferenceType(),
+            notification.getCreatedAt(),
+            notification.getReadAt()
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/doori/doori_backend/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,11 @@
+package com.doori.doori_backend.notification.dto.response;
+
+import java.util.List;
+
+public record NotificationListResponse(
+    List<NotificationItem> items,
+    long unreadCount,
+    String nextCursor,
+    boolean hasMore
+) {
+}

--- a/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.doori.doori_backend.notification.repository;
 
 import com.doori.doori_backend.notification.domain.Notification;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +18,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         @Param("limit") int limit
     );
 
-    long countByReceiverIdAndIsReadFalse(Long memberId);
+    @Query("SELECT n FROM Notification n WHERE n.id = :notificationId AND n.receiver.id = :memberId")
+    Optional<Notification> findByIdAndReceiverId(
+        @Param("notificationId") Long notificationId,
+        @Param("memberId") Long memberId
+    );
+
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.receiver.id = :memberId AND n.isRead = false")
+    long countUnreadByMemberId(@Param("memberId") Long memberId);
 
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true, n.readAt = CURRENT_TIMESTAMP WHERE n.receiver.id = :memberId AND n.isRead = false")

--- a/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
@@ -1,0 +1,25 @@
+package com.doori.doori_backend.notification.repository;
+
+import com.doori.doori_backend.notification.domain.Notification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 커서 기반 페이지네이션: cursor 미지정 시 최신순, cursor 지정 시 해당 ID 이전 항목 조회
+    @Query("SELECT n FROM Notification n WHERE n.receiver.id = :memberId AND (:cursor IS NULL OR n.id < :cursor) ORDER BY n.id DESC LIMIT :limit")
+    List<Notification> findByReceiverWithCursor(
+        @Param("memberId") Long memberId,
+        @Param("cursor") Long cursor,
+        @Param("limit") int limit
+    );
+
+    long countByReceiverIdAndIsReadFalse(Long memberId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true, n.readAt = CURRENT_TIMESTAMP WHERE n.receiver.id = :memberId AND n.isRead = false")
+    void markAllAsReadByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
@@ -28,7 +28,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("SELECT COUNT(n) FROM Notification n WHERE n.receiver.id = :memberId AND n.isRead = false")
     long countUnreadByMemberId(@Param("memberId") Long memberId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Notification n SET n.isRead = true, n.readAt = CURRENT_TIMESTAMP WHERE n.receiver.id = :memberId AND n.isRead = false")
     void markAllAsReadByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package com.doori.doori_backend.notification.repository;
 import com.doori.doori_backend.notification.domain.Notification;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,11 +12,11 @@ import org.springframework.data.repository.query.Param;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     // 커서 기반 페이지네이션: cursor 미지정 시 최신순, cursor 지정 시 해당 ID 이전 항목 조회
-    @Query("SELECT n FROM Notification n WHERE n.receiver.id = :memberId AND (:cursor IS NULL OR n.id < :cursor) ORDER BY n.id DESC LIMIT :limit")
+    @Query("SELECT n FROM Notification n WHERE n.receiver.id = :memberId AND (:cursor IS NULL OR n.id < :cursor) ORDER BY n.id DESC")
     List<Notification> findByReceiverWithCursor(
         @Param("memberId") Long memberId,
         @Param("cursor") Long cursor,
-        @Param("limit") int limit
+        Pageable pageable
     );
 
     @Query("SELECT n FROM Notification n WHERE n.id = :notificationId AND n.receiver.id = :memberId")

--- a/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
@@ -1,0 +1,64 @@
+package com.doori.doori_backend.notification.service;
+
+import com.doori.doori_backend.global.error.ErrorCode;
+import com.doori.doori_backend.global.exception.CustomException;
+import com.doori.doori_backend.notification.domain.Notification;
+import com.doori.doori_backend.notification.dto.response.NotificationItem;
+import com.doori.doori_backend.notification.dto.response.NotificationListResponse;
+import com.doori.doori_backend.notification.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private static final int DEFAULT_LIMIT = 20;
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public NotificationListResponse getNotifications(Long memberId, String cursor) {
+        Long cursorId = (cursor != null && !cursor.isBlank()) ? Long.parseLong(cursor) : null;
+        int fetchSize = DEFAULT_LIMIT + 1;
+
+        List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
+            memberId, cursorId, fetchSize);
+
+        boolean hasMore = notifications.size() == fetchSize;
+        if (hasMore) {
+            notifications = notifications.subList(0, DEFAULT_LIMIT);
+        }
+
+        List<NotificationItem> items = notifications.stream()
+            .map(NotificationItem::from)
+            .toList();
+
+        String nextCursor = (hasMore && !items.isEmpty())
+            ? String.valueOf(items.getLast().notificationId())
+            : null;
+
+        long unreadCount = notificationRepository.countByReceiverIdAndIsReadFalse(memberId);
+
+        return new NotificationListResponse(items, unreadCount, nextCursor, hasMore);
+    }
+
+    @Transactional
+    public void markAsRead(Long memberId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getReceiver().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        notification.markAsRead();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long memberId) {
+        notificationRepository.markAllAsReadByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
@@ -21,7 +21,7 @@ public class NotificationService {
 
     @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(Long memberId, String cursor) {
-        Long cursorId = (cursor != null && !cursor.isBlank()) ? Long.parseLong(cursor) : null;
+        Long cursorId = parseCursor(cursor);
         int fetchSize = DEFAULT_LIMIT + 1;
 
         List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
@@ -36,25 +36,30 @@ public class NotificationService {
             .map(NotificationItem::from)
             .toList();
 
-        String nextCursor = (hasMore && !items.isEmpty())
-            ? String.valueOf(items.getLast().notificationId())
-            : null;
+        String nextCursor = hasMore ? String.valueOf(items.getLast().notificationId()) : null;
 
-        long unreadCount = notificationRepository.countByReceiverIdAndIsReadFalse(memberId);
+        long unreadCount = notificationRepository.countUnreadByMemberId(memberId);
 
         return new NotificationListResponse(items, unreadCount, nextCursor, hasMore);
     }
 
     @Transactional
     public void markAsRead(Long memberId, Long notificationId) {
-        Notification notification = notificationRepository.findById(notificationId)
+        Notification notification = notificationRepository.findByIdAndReceiverId(notificationId, memberId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
-        if (!notification.getReceiver().getId().equals(memberId)) {
-            throw new CustomException(ErrorCode.AUTH_FORBIDDEN);
-        }
-
         notification.markAsRead();
+    }
+
+    private Long parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(cursor);
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.COMMON_BAD_REQUEST, "유효하지 않은 커서 값입니다.");
+        }
     }
 
     @Transactional

--- a/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
@@ -8,6 +8,7 @@ import com.doori.doori_backend.notification.dto.response.NotificationListRespons
 import com.doori.doori_backend.notification.repository.NotificationRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +26,7 @@ public class NotificationService {
         int fetchSize = DEFAULT_LIMIT + 1;
 
         List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
-            memberId, cursorId, fetchSize);
+            memberId, cursorId, PageRequest.of(0, fetchSize));
 
         boolean hasMore = notifications.size() == fetchSize;
         if (hasMore) {


### PR DESCRIPTION
## 연관 이슈

- Closes #26 

## 변경 요약

- 알림 도메인 엔티티 및 API 구현 (목록 조회, 단건 읽음 처리, 전체 읽음 처리)

## 구현 상세

-  도메인 설계

  - Notification 엔티티: receiver, type, title, content, isRead, referenceId,
  referenceType, createdAt, readAt 필드로 구성
  - NotificationType enum: MATCH, CHAT, COMMUNITY, SYSTEM 4가지 타입 지원
  - 중복 읽음 처리 방지: markAsRead() 내부에서 isRead 여부 체크 후 readAt 갱신

  API 엔드포인트

  GET   /api/notifications   알림 목록 조회 (커서 기반 페이지네이션) 
  PUT   /api/notifications/{notificationId}/read  단건 읽음 처리      
  PUT   /api/notifications/read-all  전체 읽음 처리      

  커서 기반 페이지네이션

  - 기본 페이지 크기: 20건
  - ?cursor={notificationId} 쿼리 파라미터로 다음 페이지 조회
  - 응답에 nextCursor, hasMore, unreadCount 포함

  에러 코드 추가

  - N001: NOTIFICATION_NOT_FOUND — 존재하지 않거나 다른 사용자의 알림 접근 시


## 테스트 결과

- 실행 명령어:
- 결과 요약:

## 체크리스트

- [ ] PR 본문에 `Closes #이슈번호` 또는 `Fixes #이슈번호`를 포함했습니다.
- [ ] 주요 구현 내용(특히 API/DB 변경 사항)을 본문에 작성했습니다.
- [ ] 로컬 검증 명령을 실행했고 결과를 본문에 작성했습니다.
