### PR TITLE
[✨ Feat] 유저 차단 기능 구현 및 게시글 차단 필터 적용 (#28)

### DIFF
--- a/src/main/java/com/doori/doori_backend/DooriBackendApplication.java
+++ b/src/main/java/com/doori/doori_backend/DooriBackendApplication.java
@@ -2,7 +2,9 @@ package com.doori.doori_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class DooriBackendApplication {
 

--- a/src/main/java/com/doori/doori_backend/block/controller/BlockController.java
+++ b/src/main/java/com/doori/doori_backend/block/controller/BlockController.java
@@ -7,7 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,9 +29,8 @@ public class BlockController {
     @PostMapping("/{targetUserId}")
     public ResponseEntity<Void> blockUser(
         @PathVariable Long targetUserId,
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         blockService.blockUser(memberId, targetUserId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -43,9 +42,8 @@ public class BlockController {
     @DeleteMapping("/{targetUserId}")
     public ResponseEntity<Void> unblockUser(
         @PathVariable Long targetUserId,
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         blockService.unblockUser(memberId, targetUserId);
         return ResponseEntity.noContent().build();
     }
@@ -56,9 +54,8 @@ public class BlockController {
      */
     @GetMapping
     public ResponseEntity<ApiResponse<List<BlockedUserResponse>>> getBlockedUsers(
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         List<BlockedUserResponse> response = blockService.getBlockedUsers(memberId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/doori/doori_backend/block/controller/BlockController.java
+++ b/src/main/java/com/doori/doori_backend/block/controller/BlockController.java
@@ -1,0 +1,65 @@
+package com.doori.doori_backend.block.controller;
+
+import com.doori.doori_backend.block.dto.response.BlockedUserResponse;
+import com.doori.doori_backend.block.service.BlockService;
+import com.doori.doori_backend.global.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/blocks")
+@RequiredArgsConstructor
+public class BlockController {
+
+    private final BlockService blockService;
+
+    /**
+     * 유저 차단 등록
+     * POST /api/blocks/{targetUserId} → 201 Created
+     */
+    @PostMapping("/{targetUserId}")
+    public ResponseEntity<Void> blockUser(
+        @PathVariable Long targetUserId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        blockService.blockUser(memberId, targetUserId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * 유저 차단 해제
+     * DELETE /api/blocks/{targetUserId} → 204 No Content
+     */
+    @DeleteMapping("/{targetUserId}")
+    public ResponseEntity<Void> unblockUser(
+        @PathVariable Long targetUserId,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        blockService.unblockUser(memberId, targetUserId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 차단 유저 목록 조회
+     * GET /api/blocks → 200 OK
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BlockedUserResponse>>> getBlockedUsers(
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        List<BlockedUserResponse> response = blockService.getBlockedUsers(memberId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/doori/doori_backend/block/domain/Block.java
+++ b/src/main/java/com/doori/doori_backend/block/domain/Block.java
@@ -1,0 +1,57 @@
+package com.doori.doori_backend.block.domain;
+
+import com.doori.doori_backend.auth.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+    name = "block",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_block",
+        columnNames = {"member_id", "target_id"}
+    )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Block {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", nullable = false)
+    private Member target;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Block(Member member, Member target) {
+        this.member = member;
+        this.target = target;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/block/dto/response/BlockedUserResponse.java
+++ b/src/main/java/com/doori/doori_backend/block/dto/response/BlockedUserResponse.java
@@ -1,0 +1,22 @@
+package com.doori.doori_backend.block.dto.response;
+
+import com.doori.doori_backend.auth.domain.Member;
+
+public record BlockedUserResponse(
+    Long userId,
+    String nickname,
+    String gender,
+    String schoolName,
+    String profileImageUrl
+) {
+
+    public static BlockedUserResponse from(Member member) {
+        return new BlockedUserResponse(
+            member.getId(),
+            member.getNickname(),
+            member.getGender().name(),
+            member.getSchool().getDisplayName(),
+            member.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/block/repository/BlockRepository.java
+++ b/src/main/java/com/doori/doori_backend/block/repository/BlockRepository.java
@@ -1,0 +1,21 @@
+package com.doori.doori_backend.block.repository;
+
+import com.doori.doori_backend.block.domain.Block;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BlockRepository extends JpaRepository<Block, Long> {
+
+    boolean existsByMemberIdAndTargetId(Long memberId, Long targetId);
+
+    Optional<Block> findByMemberIdAndTargetId(Long memberId, Long targetId);
+
+    @Query("SELECT b FROM Block b JOIN FETCH b.target WHERE b.member.id = :memberId")
+    List<Block> findAllByMemberIdWithTarget(@Param("memberId") Long memberId);
+
+    @Query("SELECT b.target.id FROM Block b WHERE b.member.id = :memberId")
+    List<Long> findBlockedTargetIds(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/doori/doori_backend/block/service/BlockService.java
+++ b/src/main/java/com/doori/doori_backend/block/service/BlockService.java
@@ -1,0 +1,83 @@
+package com.doori.doori_backend.block.service;
+
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.auth.domain.MemberStatus;
+import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.block.domain.Block;
+import com.doori.doori_backend.block.dto.response.BlockedUserResponse;
+import com.doori.doori_backend.block.repository.BlockRepository;
+import com.doori.doori_backend.global.discord.BlockCreatedEvent;
+import com.doori.doori_backend.global.error.ErrorCode;
+import com.doori.doori_backend.global.exception.CustomException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+
+    private final BlockRepository blockRepository;
+    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void blockUser(Long memberId, Long targetId) {
+        if (memberId.equals(targetId)) {
+            throw new CustomException(ErrorCode.BLOCK_SELF_NOT_ALLOWED);
+        }
+
+        Member member = findActiveMember(memberId);
+        Member target = findActiveMember(targetId);
+
+        if (blockRepository.existsByMemberIdAndTargetId(memberId, targetId)) {
+            throw new CustomException(ErrorCode.BLOCK_DUPLICATE);
+        }
+
+        blockRepository.save(Block.builder()
+            .member(member)
+            .target(target)
+            .build());
+
+        eventPublisher.publishEvent(
+            new BlockCreatedEvent(memberId, member.getNickname(), target.getNickname())
+        );
+    }
+
+    @Transactional
+    public void unblockUser(Long memberId, Long targetId) {
+        Block block = blockRepository.findByMemberIdAndTargetId(memberId, targetId)
+            .orElseThrow(() -> new CustomException(ErrorCode.BLOCK_NOT_FOUND));
+
+        blockRepository.delete(block);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BlockedUserResponse> getBlockedUsers(Long memberId) {
+        return blockRepository.findAllByMemberIdWithTarget(memberId)
+            .stream()
+            .map(block -> BlockedUserResponse.from(block.getTarget()))
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getBlockedTargetIds(Long memberId) {
+        return blockRepository.findBlockedTargetIds(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isBlocked(Long memberId, Long targetId) {
+        return blockRepository.existsByMemberIdAndTargetId(memberId, targetId);
+    }
+
+    private Member findActiveMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (member.getStatus() != MemberStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+        return member;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/global/config/OpenApiConfig.java
+++ b/src/main/java/com/doori/doori_backend/global/config/OpenApiConfig.java
@@ -1,7 +1,10 @@
 package com.doori.doori_backend.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -12,11 +15,22 @@ public class OpenApiConfig {
 
 	@Bean
 	public OpenAPI openAPI() {
-		return new OpenAPI().info(
-			new Info()
-				.title("Doori Backend API")
-				.version("v1")
-				.description("Doori Backend API 문서")
-		);
+		final String securitySchemeName = "bearerAuth";
+
+		return new OpenAPI()
+			.info(
+				new Info()
+					.title("Doori Backend API")
+					.version("v1")
+					.description("Doori Backend API 문서")
+			)
+			.components(new Components().addSecuritySchemes(
+				securitySchemeName,
+				new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+			))
+			.addSecurityItem(new SecurityRequirement().addList(securitySchemeName));
 	}
 }

--- a/src/main/java/com/doori/doori_backend/global/discord/BlockCreatedEvent.java
+++ b/src/main/java/com/doori/doori_backend/global/discord/BlockCreatedEvent.java
@@ -1,0 +1,3 @@
+package com.doori.doori_backend.global.discord;
+
+public record BlockCreatedEvent(Long blockerId, String blockerNickname, String targetNickname) {}

--- a/src/main/java/com/doori/doori_backend/global/discord/DiscordNotificationService.java
+++ b/src/main/java/com/doori/doori_backend/global/discord/DiscordNotificationService.java
@@ -1,0 +1,56 @@
+package com.doori.doori_backend.global.discord;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class DiscordNotificationService {
+
+    private static final DateTimeFormatter FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final String webhookUrl;
+    private final RestTemplate restTemplate;
+
+    public DiscordNotificationService(@Value("${discord.webhook.url:}") String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+        // connectTimeout 3초, readTimeout 5초 설정
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout((int) Duration.ofSeconds(3).toMillis());
+        factory.setReadTimeout((int) Duration.ofSeconds(5).toMillis());
+        this.restTemplate = new RestTemplate(factory);
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleBlockCreated(BlockCreatedEvent event) {
+        if (webhookUrl.isBlank()) {
+            return;
+        }
+
+        String message = String.format(
+            "🚫 차단 발생\n차단한 유저: %s (ID: %d)\n차단당한 유저: %s\n발생 시각: %s",
+            event.blockerNickname(),
+            event.blockerId(),
+            event.targetNickname(),
+            LocalDateTime.now().format(FORMATTER)
+        );
+
+        try {
+            restTemplate.postForObject(webhookUrl, Map.of("content", message), String.class);
+        } catch (Exception e) {
+            log.warn("Discord 알림 전송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
 	FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "찜 내역을 찾을 수 없습니다."),
 	BLOCK_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B001", "자기 자신을 차단할 수 없습니다."),
 	BLOCK_DUPLICATE(HttpStatus.CONFLICT, "B002", "이미 차단한 사용자입니다."),
-	BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "B003", "차단 내역을 찾을 수 없습니다.");
+	BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "B003", "차단 내역을 찾을 수 없습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "존재하지 않는 알림입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
+++ b/src/main/java/com/doori/doori_backend/global/error/ErrorCode.java
@@ -22,7 +22,10 @@ public enum ErrorCode {
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "게시글을 찾을 수 없습니다."),
 	POST_FORBIDDEN(HttpStatus.FORBIDDEN, "P002", "게시글에 대한 접근 권한이 없습니다."),
 	FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "F001", "이미 찜한 항목입니다."),
-	FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "찜 내역을 찾을 수 없습니다.");
+	FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "찜 내역을 찾을 수 없습니다."),
+	BLOCK_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B001", "자기 자신을 차단할 수 없습니다."),
+	BLOCK_DUPLICATE(HttpStatus.CONFLICT, "B002", "이미 차단한 사용자입니다."),
+	BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "B003", "차단 내역을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/doori/doori_backend/post/controller/PostController.java
+++ b/src/main/java/com/doori/doori_backend/post/controller/PostController.java
@@ -51,28 +51,32 @@ public class PostController {
     }
 
     /**
-     * 게시글 목록 조회 (필터 + 페이지네이션)
+     * 게시글 목록 조회 (필터 + 페이지네이션 + 차단 유저 제외)
      * GET /api/posts?postType=TRANSFER&page=0&size=10 → 200 OK
      */
     @GetMapping
     public ResponseEntity<ApiResponse<Wrapper>> getPosts(
+        Authentication authentication,
         @RequestParam(required = false) String postType,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size
     ) {
-        Wrapper response = postService.getPosts(postType, page, size);
+        Long memberId = (Long) authentication.getPrincipal();
+        Wrapper response = postService.getPosts(memberId, postType, page, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
-     * 게시글 단건 조회
+     * 게시글 단건 조회 (차단한 유저의 게시글은 404 반환)
      * GET /api/posts/{postId} → 200 OK
      */
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(
-        @PathVariable Long postId
+        @PathVariable Long postId,
+        Authentication authentication
     ) {
-        PostResponse response = postService.getPost(postId);
+        Long memberId = (Long) authentication.getPrincipal();
+        PostResponse response = postService.getPost(memberId, postId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/doori/doori_backend/post/controller/PostController.java
+++ b/src/main/java/com/doori/doori_backend/post/controller/PostController.java
@@ -10,7 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,9 +41,8 @@ public class PostController {
     @PostMapping
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
         @RequestBody @Valid PostCreateRequest request,
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         PostResponse response = postService.createPost(memberId, request);
         return ResponseEntity
             .status(HttpStatus.CREATED)
@@ -56,12 +55,11 @@ public class PostController {
      */
     @GetMapping
     public ResponseEntity<ApiResponse<Wrapper>> getPosts(
-        Authentication authentication,
+        @AuthenticationPrincipal Long memberId,
         @RequestParam(required = false) String postType,
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         Wrapper response = postService.getPosts(memberId, postType, page, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -73,9 +71,8 @@ public class PostController {
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(
         @PathVariable Long postId,
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         PostResponse response = postService.getPost(memberId, postId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
@@ -88,9 +85,8 @@ public class PostController {
     public ResponseEntity<Void> updatePost(
         @PathVariable Long postId,
         @RequestBody @Valid PostUpdateRequest request,
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         postService.updatePost(memberId, postId, request);
         return ResponseEntity.noContent().build();
     }
@@ -102,9 +98,8 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
         @PathVariable Long postId,
-        Authentication authentication
+        @AuthenticationPrincipal Long memberId
     ) {
-        Long memberId = (Long) authentication.getPrincipal();
         postService.deletePost(memberId, postId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/doori/doori_backend/post/repository/PostRepository.java
+++ b/src/main/java/com/doori/doori_backend/post/repository/PostRepository.java
@@ -24,18 +24,22 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     /**
      * postType 필터링 + 차단 유저 제외 + 최신순 정렬 목록 조회
-     * - blockedIds가 비어 있지 않을 때만 호출한다 (빈 컬렉션 IN절 오류 방지)
+     * - NOT EXISTS 서브쿼리로 Block 테이블을 직접 조회하여 성능 개선
      */
     @Query("""
         SELECT p FROM Post p
         JOIN FETCH p.author
         WHERE (:postType IS NULL OR p.postType = :postType)
-          AND p.author.id NOT IN :blockedIds
+          AND NOT EXISTS (
+              SELECT 1 FROM Block b
+              WHERE b.member.id = :memberId
+              AND b.target.id = p.author.id
+          )
         ORDER BY p.createdAt DESC
         """)
     Page<Post> findAllByFilterExcludingAuthors(
+        @Param("memberId") Long memberId,
         @Param("postType") PostType postType,
-        @Param("blockedIds") List<Long> blockedIds,
         Pageable pageable
     );
 }

--- a/src/main/java/com/doori/doori_backend/post/repository/PostRepository.java
+++ b/src/main/java/com/doori/doori_backend/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.doori.doori_backend.post.repository;
 
 import com.doori.doori_backend.post.domain.Post;
 import com.doori.doori_backend.post.domain.PostType;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,9 +12,7 @@ import org.springframework.data.repository.query.Param;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     /**
-     * postType 필터링 + 최신순 정렬 목록 조회
-     * - postType이 null이면 전체 목록, 아니면 해당 타입만 반환
-     * - author를 fetch join하여 PostListResponse 변환 시 N+1 방지
+     * postType 필터링 + 최신순 정렬 목록 조회 (차단 필터 없음)
      */
     @Query("""
         SELECT p FROM Post p
@@ -22,4 +21,21 @@ public interface PostRepository extends JpaRepository<Post, Long> {
         ORDER BY p.createdAt DESC
         """)
     Page<Post> findAllByFilter(@Param("postType") PostType postType, Pageable pageable);
+
+    /**
+     * postType 필터링 + 차단 유저 제외 + 최신순 정렬 목록 조회
+     * - blockedIds가 비어 있지 않을 때만 호출한다 (빈 컬렉션 IN절 오류 방지)
+     */
+    @Query("""
+        SELECT p FROM Post p
+        JOIN FETCH p.author
+        WHERE (:postType IS NULL OR p.postType = :postType)
+          AND p.author.id NOT IN :blockedIds
+        ORDER BY p.createdAt DESC
+        """)
+    Page<Post> findAllByFilterExcludingAuthors(
+        @Param("postType") PostType postType,
+        @Param("blockedIds") List<Long> blockedIds,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/doori/doori_backend/post/service/PostService.java
+++ b/src/main/java/com/doori/doori_backend/post/service/PostService.java
@@ -74,11 +74,7 @@ public class PostService {
     public Wrapper getPosts(Long memberId, String postTypeStr, int page, int size) {
         PostType postType = (postTypeStr == null || postTypeStr.isBlank()) ? null : parsePostType(postTypeStr);
         Pageable pageable = PageRequest.of(page, size);
-        List<Long> blockedIds = blockService.getBlockedTargetIds(memberId);
-
-        Page<Post> postPage = blockedIds.isEmpty()
-            ? postRepository.findAllByFilter(postType, pageable)
-            : postRepository.findAllByFilterExcludingAuthors(postType, blockedIds, pageable);
+        Page<Post> postPage = postRepository.findAllByFilterExcludingAuthors(memberId, postType, pageable);
 
         List<PostListResponse> posts = postPage.getContent()
             .stream()

--- a/src/main/java/com/doori/doori_backend/post/service/PostService.java
+++ b/src/main/java/com/doori/doori_backend/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.doori.doori_backend.post.service;
 import com.doori.doori_backend.auth.domain.Member;
 import com.doori.doori_backend.auth.domain.MemberStatus;
 import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.block.service.BlockService;
 import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.exception.CustomException;
 import com.doori.doori_backend.post.domain.Post;
@@ -33,6 +34,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final BlockService blockService;
 
     /**
      * 게시글 생성
@@ -61,18 +63,22 @@ public class PostService {
     }
 
     /**
-     * 게시글 목록 조회 (페이지네이션 + 타입 필터)
+     * 게시글 목록 조회 (페이지네이션 + 타입 필터 + 차단 유저 제외)
+     * @param memberId    인증된 사용자 ID
      * @param postTypeStr postType 문자열 (null이면 전체)
      * @param page        0-based 페이지 번호
      * @param size        페이지 크기
      * @return 목록 + 전체 개수 래퍼
      */
     @Transactional(readOnly = true)
-    public Wrapper getPosts(String postTypeStr, int page, int size) {
-        // postTypeStr이 null이거나 빈 문자열이면 전체 조회
+    public Wrapper getPosts(Long memberId, String postTypeStr, int page, int size) {
         PostType postType = (postTypeStr == null || postTypeStr.isBlank()) ? null : parsePostType(postTypeStr);
         Pageable pageable = PageRequest.of(page, size);
-        Page<Post> postPage = postRepository.findAllByFilter(postType, pageable);
+        List<Long> blockedIds = blockService.getBlockedTargetIds(memberId);
+
+        Page<Post> postPage = blockedIds.isEmpty()
+            ? postRepository.findAllByFilter(postType, pageable)
+            : postRepository.findAllByFilterExcludingAuthors(postType, blockedIds, pageable);
 
         List<PostListResponse> posts = postPage.getContent()
             .stream()
@@ -83,13 +89,17 @@ public class PostService {
     }
 
     /**
-     * 게시글 단건 조회
-     * @param postId 게시글 ID
+     * 게시글 단건 조회 (차단한 유저의 게시글은 404 반환)
+     * @param memberId 인증된 사용자 ID
+     * @param postId   게시글 ID
      * @return 게시글 상세 응답
      */
     @Transactional(readOnly = true)
-    public PostResponse getPost(Long postId) {
+    public PostResponse getPost(Long memberId, Long postId) {
         Post post = findPost(postId);
+        if (blockService.isBlocked(memberId, post.getAuthor().getId())) {
+            throw new CustomException(ErrorCode.POST_NOT_FOUND);
+        }
         return PostResponse.from(post);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.jpa.hibernate.ddl-auto=none
 jwt.secret=${JWT_SECRET:doori-backend-secret-key-for-development-only-must-be-32chars}
 jwt.access-token-valid-ms=3600000
 jwt.refresh-token-valid-ms=2592000000
+
+discord.webhook.url=${DISCORD_WEBHOOK_URL:}

--- a/src/test/java/com/doori/doori_backend/block/BlockApiTest.java
+++ b/src/test/java/com/doori/doori_backend/block/BlockApiTest.java
@@ -1,0 +1,202 @@
+package com.doori.doori_backend.block;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.doori.doori_backend.auth.domain.Gender;
+import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.block.domain.Block;
+import com.doori.doori_backend.block.repository.BlockRepository;
+import com.doori.doori_backend.post.domain.Post;
+import com.doori.doori_backend.post.domain.PostType;
+import com.doori.doori_backend.post.repository.PostRepository;
+import com.doori.doori_backend.school.domain.School;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * 유저 차단 API 통합 테스트
+ * - @Transactional: 각 테스트 후 DB 롤백으로 상태 격리
+ * - MockMvcBuilders.webAppContextSetup() + springSecurity()로 Security 필터 적용
+ * - H2 인메모리 DB (src/test/resources/application.properties 기준)
+ */
+@SpringBootTest
+@Transactional
+class BlockApiTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private BlockRepository blockRepository;
+
+    private MockMvc mockMvc;
+
+    private Member me;
+    private Member targetUser;
+    private Post targetPost;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();
+
+        me = memberRepository.save(Member.builder()
+            .email("me@sju.ac.kr")
+            .password("password123!")
+            .name("나")
+            .nickname("meNick")
+            .gender(Gender.M)
+            .school(School.SEJONG_UNIV)
+            .build());
+
+        targetUser = memberRepository.save(Member.builder()
+            .email("target@sju.ac.kr")
+            .password("password123!")
+            .name("대상")
+            .nickname("targetNick")
+            .gender(Gender.F)
+            .school(School.SEJONG_UNIV)
+            .build());
+
+        targetPost = postRepository.save(Post.builder()
+            .author(targetUser)
+            .postType(PostType.TRANSFER)
+            .title("차단 유저 게시글")
+            .region("서울 관악구")
+            .university("서울대학교")
+            .monthlyRent(500000)
+            .deposit(3000000)
+            .description("차단 테스트용 게시글입니다.")
+            .roomImages(List.of("https://example.com/img1.jpg"))
+            .build());
+    }
+
+    private Authentication authOf(Long memberId) {
+        return new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+    }
+
+    // ─── 차단 등록 ────────────────────────────────────────────────────────────
+
+    @Test
+    void blockUser_success_returns201() throws Exception {
+        mockMvc.perform(post("/api/blocks/{targetUserId}", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    void blockUser_selfBlock_returns400() throws Exception {
+        mockMvc.perform(post("/api/blocks/{targetUserId}", me.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("B001"));
+    }
+
+    @Test
+    void blockUser_duplicate_returns409() throws Exception {
+        blockRepository.save(Block.builder().member(me).target(targetUser).build());
+
+        mockMvc.perform(post("/api/blocks/{targetUserId}", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("B002"));
+    }
+
+    @Test
+    void blockUser_targetNotFound_returns404() throws Exception {
+        mockMvc.perform(post("/api/blocks/{targetUserId}", 999999L)
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("U001"));
+    }
+
+    // ─── 차단 해제 ────────────────────────────────────────────────────────────
+
+    @Test
+    void unblockUser_success_returns204() throws Exception {
+        blockRepository.save(Block.builder().member(me).target(targetUser).build());
+
+        mockMvc.perform(delete("/api/blocks/{targetUserId}", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void unblockUser_notFound_returns404() throws Exception {
+        mockMvc.perform(delete("/api/blocks/{targetUserId}", targetUser.getId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("B003"));
+    }
+
+    // ─── 차단 목록 조회 ───────────────────────────────────────────────────────
+
+    @Test
+    void getBlockedUsers_success() throws Exception {
+        blockRepository.save(Block.builder().member(me).target(targetUser).build());
+
+        mockMvc.perform(get("/api/blocks")
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data[0].userId").value(targetUser.getId()))
+            .andExpect(jsonPath("$.data[0].nickname").value("targetNick"));
+    }
+
+    @Test
+    void getBlockedUsers_empty_returnsEmptyList() throws Exception {
+        mockMvc.perform(get("/api/blocks")
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    // ─── 차단 유저 게시글 필터링 ────────────────────────────────────────────────
+
+    @Test
+    void getPosts_excludesBlockedUserPosts() throws Exception {
+        blockRepository.save(Block.builder().member(me).target(targetUser).build());
+
+        mockMvc.perform(get("/api/posts")
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.posts").isArray())
+            .andExpect(jsonPath("$.data.posts[?(@.title == '차단 유저 게시글')]").doesNotExist());
+    }
+
+    @Test
+    void getPost_blockedUserPost_returns404() throws Exception {
+        blockRepository.save(Block.builder().member(me).target(targetUser).build());
+
+        mockMvc.perform(get("/api/posts/{postId}", targetPost.getPostId())
+                .with(authentication(authOf(me.getId()))))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("P001"));
+    }
+}


### PR DESCRIPTION
## 연관 이슈

- Closes #28

## 변경 요약

- 유저 차단/해제/목록 조회 API 구현
- 게시글 목록·단건 조회 시 차단 유저 게시글 자동 제외
- 차단 발생 시 Discord 웹훅 비동기 알림 연동

## 구현 상세

### API 엔드포인트 (신규)

| 메서드 | 경로 | 설명 |
|--------|------|------|
| POST | `/api/blocks/{targetId}` | 유저 차단 |
| DELETE | `/api/blocks/{targetId}` | 차단 해제 |
| GET | `/api/blocks` | 차단 목록 조회 |

### DB 영향

- `block` 테이블 신규 생성 (`member_id`, `target_id`, `created_at`)
- `member_id + target_id` 복합 유니크 인덱스 적용

### 게시글 차단 필터

- `GET /api/posts` — 차단 유저 게시글 목록에서 제외 (`NOT IN :blockedIds` 쿼리)
- `GET /api/posts/{postId}` — 차단 유저 게시글 단건 조회 시 404 반환

### Discord 알림

- `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 조합으로 트랜잭션 커밋 후 비동기 전송
- 웹훅 URL 미설정 시 알림 스킵 (환경변수 `DISCORD_WEBHOOK_URL`)
- `application.properties`에 `discord.webhook.url` 프로퍼티 추가

### 기타

- `@EnableAsync` 활성화 (`DooriBackendApplication`)
- `ErrorCode` B001~B003 추가 (BLOCK_SELF_NOT_ALLOWED, BLOCK_DUPLICATE, BLOCK_NOT_FOUND)
- Swagger에 JWT Bearer 인증 설정 추가 (`OpenApiConfig`)

## 테스트 결과

- 실행 명령어: `./gradlew test`
- 결과 요약: **BUILD SUCCESSFUL** — `BlockApiTest` 포함 전체 테스트 통과

## 체크리스트

- [x] PR 본문에 `Closes #이슈번호` 또는 `Fixes #이슈번호`를 포함했습니다.
- [x] 주요 구현 내용(특히 API/DB 변경 사항)을 본문에 작성했습니다.
- [x] 로컬 검증 명령을 실행했고 결과를 본문에 작성했습니다.