### PR TITLE
[♻️ Refactor] Auth 패키지에서 User 도메인 분리 (#30)

### DIFF
--- a/src/main/java/com/doori/doori_backend/auth/domain/Gender.java
+++ b/src/main/java/com/doori/doori_backend/auth/domain/Gender.java
@@ -1,5 +1,0 @@
-package com.doori.doori_backend.auth.domain;
-
-public enum Gender {
-    M, F
-}

--- a/src/main/java/com/doori/doori_backend/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/doori/doori_backend/auth/dto/request/SignupRequest.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.auth.dto.request;
 
-import com.doori.doori_backend.auth.domain.Gender;
+import com.doori.doori_backend.user.domain.Gender;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/doori/doori_backend/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/doori/doori_backend/auth/dto/response/SignupResponse.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.auth.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 
 public record SignupResponse(
     Long userId,

--- a/src/main/java/com/doori/doori_backend/auth/dto/response/UserInfo.java
+++ b/src/main/java/com/doori/doori_backend/auth/dto/response/UserInfo.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.auth.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 
 public record UserInfo(
     Long userId,

--- a/src/main/java/com/doori/doori_backend/auth/service/AuthService.java
+++ b/src/main/java/com/doori/doori_backend/auth/service/AuthService.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.auth.service;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import com.doori.doori_backend.school.domain.School;
 import com.doori.doori_backend.auth.domain.RefreshToken;
 import com.doori.doori_backend.auth.dto.request.EmailSendRequest;
@@ -14,7 +14,7 @@ import com.doori.doori_backend.auth.dto.response.SignupResponse;
 import com.doori.doori_backend.auth.dto.response.TokenResponse;
 import com.doori.doori_backend.auth.dto.response.UserInfo;
 import com.doori.doori_backend.auth.jwt.JwtProvider;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.auth.repository.RefreshTokenRepository;
 import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.exception.CustomException;

--- a/src/main/java/com/doori/doori_backend/block/domain/Block.java
+++ b/src/main/java/com/doori/doori_backend/block/domain/Block.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.block.domain;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/doori/doori_backend/block/dto/response/BlockedUserResponse.java
+++ b/src/main/java/com/doori/doori_backend/block/dto/response/BlockedUserResponse.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.block.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 
 public record BlockedUserResponse(
     Long userId,

--- a/src/main/java/com/doori/doori_backend/block/service/BlockService.java
+++ b/src/main/java/com/doori/doori_backend/block/service/BlockService.java
@@ -1,8 +1,8 @@
 package com.doori.doori_backend.block.service;
 
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.domain.MemberStatus;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.block.domain.Block;
 import com.doori.doori_backend.block.dto.response.BlockedUserResponse;
 import com.doori.doori_backend.block.repository.BlockRepository;

--- a/src/main/java/com/doori/doori_backend/favorite/domain/PostFavorite.java
+++ b/src/main/java/com/doori/doori_backend/favorite/domain/PostFavorite.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.favorite.domain;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import com.doori.doori_backend.post.domain.Post;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/doori/doori_backend/favorite/domain/UserFavorite.java
+++ b/src/main/java/com/doori/doori_backend/favorite/domain/UserFavorite.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.favorite.domain;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/doori/doori_backend/favorite/dto/response/FavoriteUserResponse.java
+++ b/src/main/java/com/doori/doori_backend/favorite/dto/response/FavoriteUserResponse.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.favorite.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 
 /**
  * 찜한 유저 목록 응답 DTO

--- a/src/main/java/com/doori/doori_backend/favorite/service/FavoriteService.java
+++ b/src/main/java/com/doori/doori_backend/favorite/service/FavoriteService.java
@@ -1,8 +1,8 @@
 package com.doori.doori_backend.favorite.service;
 
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.domain.MemberStatus;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.favorite.domain.PostFavorite;
 import com.doori.doori_backend.favorite.domain.UserFavorite;
 import com.doori.doori_backend.favorite.dto.response.FavoritePostResponse;

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/LifestyleProfile.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/LifestyleProfile.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.lifestyle.domain;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/doori/doori_backend/lifestyle/repository/LifestyleProfileRepository.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/repository/LifestyleProfileRepository.java
@@ -1,7 +1,7 @@
 package com.doori.doori_backend.lifestyle.repository;
 
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.domain.MemberStatus;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
 import com.doori.doori_backend.lifestyle.domain.HousingType;
 import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
 import java.util.List;

--- a/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.notification.domain;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/doori/doori_backend/post/domain/Post.java
+++ b/src/main/java/com/doori/doori_backend/post/domain/Post.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.post.domain;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;

--- a/src/main/java/com/doori/doori_backend/post/service/PostService.java
+++ b/src/main/java/com/doori/doori_backend/post/service/PostService.java
@@ -1,8 +1,8 @@
 package com.doori.doori_backend.post.service;
 
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.domain.MemberStatus;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.block.service.BlockService;
 import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.exception.CustomException;

--- a/src/main/java/com/doori/doori_backend/user/domain/Gender.java
+++ b/src/main/java/com/doori/doori_backend/user/domain/Gender.java
@@ -1,0 +1,5 @@
+package com.doori.doori_backend.user.domain;
+
+public enum Gender {
+    M, F
+}

--- a/src/main/java/com/doori/doori_backend/user/domain/Member.java
+++ b/src/main/java/com/doori/doori_backend/user/domain/Member.java
@@ -1,4 +1,4 @@
-package com.doori.doori_backend.auth.domain;
+package com.doori.doori_backend.user.domain;
 
 import com.doori.doori_backend.school.domain.School;
 import jakarta.persistence.Column;

--- a/src/main/java/com/doori/doori_backend/user/domain/MemberStatus.java
+++ b/src/main/java/com/doori/doori_backend/user/domain/MemberStatus.java
@@ -1,4 +1,4 @@
-package com.doori.doori_backend.auth.domain;
+package com.doori.doori_backend.user.domain;
 
 public enum MemberStatus {
     ACTIVE, INACTIVE, BANNED

--- a/src/main/java/com/doori/doori_backend/user/dto/response/ExploreItem.java
+++ b/src/main/java/com/doori/doori_backend/user/dto/response/ExploreItem.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.user.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
 
 public record ExploreItem(

--- a/src/main/java/com/doori/doori_backend/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/doori/doori_backend/user/dto/response/MyProfileResponse.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.user.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import java.time.LocalDateTime;
 
 public record MyProfileResponse(

--- a/src/main/java/com/doori/doori_backend/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/doori/doori_backend/user/dto/response/UserProfileResponse.java
@@ -1,6 +1,6 @@
 package com.doori.doori_backend.user.dto.response;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 
 public record UserProfileResponse(
     Long userId,

--- a/src/main/java/com/doori/doori_backend/user/repository/MemberRepository.java
+++ b/src/main/java/com/doori/doori_backend/user/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.doori.doori_backend.auth.repository;
+package com.doori.doori_backend.user.repository;
 
-import com.doori.doori_backend.auth.domain.Member;
+import com.doori.doori_backend.user.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
+++ b/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
@@ -1,8 +1,8 @@
 package com.doori.doori_backend.user.service;
 
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.domain.MemberStatus;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.exception.CustomException;
 import com.doori.doori_backend.lifestyle.domain.HousingType;

--- a/src/main/java/com/doori/doori_backend/user/service/UserProfileService.java
+++ b/src/main/java/com/doori/doori_backend/user/service/UserProfileService.java
@@ -1,8 +1,8 @@
 package com.doori.doori_backend.user.service;
 
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.domain.MemberStatus;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.auth.repository.RefreshTokenRepository;
 import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.exception.CustomException;

--- a/src/test/java/com/doori/doori_backend/block/BlockApiTest.java
+++ b/src/test/java/com/doori/doori_backend/block/BlockApiTest.java
@@ -8,9 +8,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.doori.doori_backend.auth.domain.Gender;
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Gender;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.block.domain.Block;
 import com.doori.doori_backend.block.repository.BlockRepository;
 import com.doori.doori_backend.post.domain.Post;

--- a/src/test/java/com/doori/doori_backend/favorite/FavoriteApiTest.java
+++ b/src/test/java/com/doori/doori_backend/favorite/FavoriteApiTest.java
@@ -8,9 +8,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.doori.doori_backend.auth.domain.Gender;
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Gender;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.favorite.domain.PostFavorite;
 import com.doori.doori_backend.favorite.domain.UserFavorite;
 import com.doori.doori_backend.favorite.repository.PostFavoriteRepository;

--- a/src/test/java/com/doori/doori_backend/post/PostControllerIntegrationTest.java
+++ b/src/test/java/com/doori/doori_backend/post/PostControllerIntegrationTest.java
@@ -9,9 +9,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
-import com.doori.doori_backend.auth.domain.Gender;
-import com.doori.doori_backend.auth.domain.Member;
-import com.doori.doori_backend.auth.repository.MemberRepository;
+import com.doori.doori_backend.user.domain.Gender;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.repository.MemberRepository;
 import com.doori.doori_backend.post.domain.Post;
 import com.doori.doori_backend.post.domain.PostType;
 import com.doori.doori_backend.post.repository.PostRepository;


### PR DESCRIPTION
## 연관 이슈

Closes #30

## 변경 요약

- `auth` 패키지에 혼재되어 있던 User 도메인을 `user` 패키지로 분리

## 구현 상세

| 이동 전 | 이동 후 |
|---|---|
| `auth/domain/Member.java` | `user/domain/Member.java` |
| `auth/domain/Gender.java` | `user/domain/Gender.java` |
| `auth/domain/MemberStatus.java` | `user/domain/MemberStatus.java` |
| `auth/repository/MemberRepository.java` | `user/repository/MemberRepository.java` |

- 위 클래스를 참조하는 파일 25개의 import 경로 일괄 수정
- `auth` 패키지는 JWT, 이메일 인증, 토큰 발급 등 순수 인증 책임만 담당
- `user` 패키지가 사용자 엔티티와 리포지토리를 관리

## 테스트 결과

```
./gradlew clean build → BUILD SUCCESSFUL
```

## 체크리스트

- [x] 변경 파일이 이번 작업 범위에 정확히 맞는다.
- [x] 테스트를 실행했다. (`./gradlew clean build`)
- [x] PR 본문에 `Closes #30` 포함