### PR TITLE
[✨ Feat] 디자인 기반 생활 성향/알림/프로필 카드 정합성 맞춤 (#32)

### DIFF
--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/Atmosphere.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/Atmosphere.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum Atmosphere {
+    QUIET,      // 조용하게
+    MODERATE,   // 적당히 교류
+    SOCIAL      // 자주 어울리기
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/CleaningCycle.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/CleaningCycle.java
@@ -1,0 +1,8 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum CleaningCycle {
+    DAILY,      // 매일
+    WEEKLY,     // 주 1회
+    MONTHLY,    // 월 1회
+    OTHER       // 그 외
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/ImportanceLevel.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/ImportanceLevel.java
@@ -1,0 +1,25 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+/**
+ * 청결도, 소음 등 각 항목에 대한 중요도/민감도를 수치로 표현합니다.
+ *
+ * 현재 점수값(score)은 임시값으로, 매칭 스코어 계산 로직 확정 후 회의를 거쳐 조정할 예정입니다.
+ * - VERY_IMPORTANT(5): 매우 중요해요 / 매우 민감해요
+ * - NORMAL(3):         보통이에요
+ * - NOT_CARE(1):       크게 신경 안 써요 / 둔감해요
+ */
+public enum ImportanceLevel {
+    VERY_IMPORTANT(5),
+    NORMAL(3),
+    NOT_CARE(1);
+
+    private final int score;
+
+    ImportanceLevel(int score) {
+        this.score = score;
+    }
+
+    public int getScore() {
+        return score;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/LifestyleProfile.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/LifestyleProfile.java
@@ -38,15 +38,62 @@ public class LifestyleProfile {
 
     private Boolean isSmoker;
 
+    @Enumerated(EnumType.STRING)
+    private SleepTime sleepTime;
+
+    @Enumerated(EnumType.STRING)
+    private WakeUpTime wakeUpTime;
+
+    @Enumerated(EnumType.STRING)
+    private CleaningCycle cleaningCycle;
+
+    @Enumerated(EnumType.STRING)
+    private ImportanceLevel cleanlinessLevel;
+
+    @Enumerated(EnumType.STRING)
+    private ImportanceLevel noiseSensitivity;
+
+    @Enumerated(EnumType.STRING)
+    private Atmosphere atmosphere;
+
+    @Enumerated(EnumType.STRING)
+    private PriorityCriteria priorityCriteria;
+
+    @Column(length = 200)
+    private String bio;
+
+    @Column(length = 200)
+    private String roommateWish;
+
     @Builder
-    public LifestyleProfile(Member member, HousingType housingType, String preferredRegion, Boolean isSmoker) {
+    public LifestyleProfile(Member member, HousingType housingType, String preferredRegion,
+        Boolean isSmoker, SleepTime sleepTime, WakeUpTime wakeUpTime,
+        CleaningCycle cleaningCycle, ImportanceLevel cleanlinessLevel,
+        ImportanceLevel noiseSensitivity, Atmosphere atmosphere,
+        PriorityCriteria priorityCriteria, String bio, String roommateWish) {
         this.member = member;
         this.housingType = housingType;
         this.preferredRegion = preferredRegion;
         this.isSmoker = isSmoker;
+        this.sleepTime = sleepTime;
+        this.wakeUpTime = wakeUpTime;
+        this.cleaningCycle = cleaningCycle;
+        this.cleanlinessLevel = cleanlinessLevel;
+        this.noiseSensitivity = noiseSensitivity;
+        this.atmosphere = atmosphere;
+        this.priorityCriteria = priorityCriteria;
+        this.bio = bio;
+        this.roommateWish = roommateWish;
     }
 
     public boolean isComplete() {
-        return housingType != null && preferredRegion != null;
+        return housingType != null
+            && isSmoker != null
+            && sleepTime != null
+            && wakeUpTime != null
+            && cleaningCycle != null
+            && cleanlinessLevel != null
+            && noiseSensitivity != null
+            && atmosphere != null;
     }
 }

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/PriorityCriteria.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/PriorityCriteria.java
@@ -1,0 +1,9 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum PriorityCriteria {
+    SLEEP_PATTERN,  // 수면패턴
+    CLEANLINESS,    // 청결도
+    SMOKING,        // 흡연 여부
+    NOISE,          // 소음 정도
+    PERSONALITY     // 성격
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/SleepTime.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/SleepTime.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum SleepTime {
+    EARLY,      // 일찍 자요
+    LATE,       // 늦게 자요
+    IRREGULAR   // 일정하지 않아요
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/StringToHousingTypeConverter.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/StringToHousingTypeConverter.java
@@ -1,0 +1,13 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToHousingTypeConverter implements Converter<String, HousingType> {
+
+    @Override
+    public HousingType convert(String source) {
+        return HousingType.fromValue(source);
+    }
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/WakeUpTime.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/WakeUpTime.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum WakeUpTime {
+    EARLY,      // 일찍 일어나요
+    LATE,       // 늦게 일어나요
+    IRREGULAR   // 일정하지 않아요
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/repository/LifestyleProfileRepository.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/repository/LifestyleProfileRepository.java
@@ -31,6 +31,7 @@ public interface LifestyleProfileRepository extends JpaRepository<LifestyleProfi
     @Query("""
         SELECT lp FROM LifestyleProfile lp
         WHERE lp.member.status = :status
+          AND lp.member.id != :memberId
           AND (:housingType IS NULL OR lp.housingType = :housingType)
           AND (:isSmoker IS NULL OR lp.isSmoker = :isSmoker)
           AND lp.member.id > :cursorId
@@ -38,6 +39,7 @@ public interface LifestyleProfileRepository extends JpaRepository<LifestyleProfi
         """)
     List<LifestyleProfile> findForExplore(
         @Param("status") MemberStatus status,
+        @Param("memberId") Long memberId,
         @Param("housingType") HousingType housingType,
         @Param("isSmoker") Boolean isSmoker,
         @Param("cursorId") Long cursorId,

--- a/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.doori.doori_backend.notification.controller;
 
 import com.doori.doori_backend.global.response.ApiResponse;
+import com.doori.doori_backend.notification.domain.NotificationType;
 import com.doori.doori_backend.notification.dto.response.NotificationListResponse;
 import com.doori.doori_backend.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class NotificationController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
-        @RequestParam(required = false) String type,
+        @RequestParam(required = false) NotificationType type,
         @RequestParam(required = false) String cursor,
         Authentication authentication
     ) {

--- a/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/doori/doori_backend/notification/controller/NotificationController.java
@@ -22,11 +22,12 @@ public class NotificationController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<NotificationListResponse>> getNotifications(
+        @RequestParam(required = false) String type,
         @RequestParam(required = false) String cursor,
         Authentication authentication
     ) {
         Long memberId = (Long) authentication.getPrincipal();
-        return ResponseEntity.ok(ApiResponse.success(notificationService.getNotifications(memberId, cursor)));
+        return ResponseEntity.ok(ApiResponse.success(notificationService.getNotifications(memberId, type, cursor)));
     }
 
     @PutMapping("/{notificationId}/read")

--- a/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/Notification.java
@@ -4,8 +4,7 @@ import com.doori.doori_backend.user.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.Convert;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,7 +35,7 @@ public class Notification {
     @JoinColumn(name = "member_id", nullable = false)
     private Member receiver;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = NotificationTypeConverter.class)
     @Column(nullable = false)
     private NotificationType type;
 

--- a/src/main/java/com/doori/doori_backend/notification/domain/NotificationType.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/NotificationType.java
@@ -1,8 +1,10 @@
 package com.doori.doori_backend.notification.domain;
 
 public enum NotificationType {
-    MATCH,
-    CHAT,
-    COMMUNITY,
-    SYSTEM
+    MATCH_REQUEST,      // 매칭 요청
+    MATCH_RESULT,       // 매칭 결과
+    CHAT,               // 채팅 알림 (채팅 탭)
+    LIFESTYLE_RULE,     // 생활 규칙 알림 (룸메와의 생활 규칙 설정 — 트리거 로직 미구현, 타입 예약)
+    COMMUNITY_COMMENT,  // 커뮤니티 댓글
+    SYSTEM              // 시스템 알림
 }

--- a/src/main/java/com/doori/doori_backend/notification/domain/NotificationTypeConverter.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/NotificationTypeConverter.java
@@ -1,0 +1,23 @@
+package com.doori.doori_backend.notification.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class NotificationTypeConverter implements AttributeConverter<NotificationType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(NotificationType type) {
+        return type == null ? null : type.name();
+    }
+
+    @Override
+    public NotificationType convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        return switch (dbData) {
+            case "MATCH", "MATCH_REQUEST" -> NotificationType.MATCH_REQUEST;
+            case "COMMUNITY", "COMMUNITY_COMMENT" -> NotificationType.COMMUNITY_COMMENT;
+            default -> NotificationType.valueOf(dbData);
+        };
+    }
+}

--- a/src/main/java/com/doori/doori_backend/notification/domain/StringToNotificationTypeConverter.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/StringToNotificationTypeConverter.java
@@ -1,0 +1,13 @@
+package com.doori.doori_backend.notification.domain;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToNotificationTypeConverter implements Converter<String, NotificationType> {
+
+    @Override
+    public NotificationType convert(String source) {
+        return NotificationType.valueOf(source.toUpperCase());
+    }
+}

--- a/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/doori/doori_backend/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.doori.doori_backend.notification.repository;
 
 import com.doori.doori_backend.notification.domain.Notification;
+import com.doori.doori_backend.notification.domain.NotificationType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -11,11 +12,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    // 커서 기반 페이지네이션: cursor 미지정 시 최신순, cursor 지정 시 해당 ID 이전 항목 조회
-    @Query("SELECT n FROM Notification n WHERE n.receiver.id = :memberId AND (:cursor IS NULL OR n.id < :cursor) ORDER BY n.id DESC")
+    // 커서 기반 페이지네이션: type=null이면 전체 조회, 지정 시 해당 타입만 조회
+    @Query("""
+        SELECT n FROM Notification n
+        WHERE n.receiver.id = :memberId
+          AND (:cursor IS NULL OR n.id < :cursor)
+          AND (:type IS NULL OR n.type = :type)
+        ORDER BY n.id DESC
+        """)
     List<Notification> findByReceiverWithCursor(
         @Param("memberId") Long memberId,
         @Param("cursor") Long cursor,
+        @Param("type") NotificationType type,
         Pageable pageable
     );
 

--- a/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
@@ -54,6 +54,11 @@ public class NotificationService {
         notification.markAsRead();
     }
 
+    @Transactional
+    public void markAllAsRead(Long memberId) {
+        notificationRepository.markAllAsReadByMemberId(memberId);
+    }
+
     private Long parseCursor(String cursor) {
         if (cursor == null || cursor.isBlank()) {
             return null;
@@ -74,10 +79,5 @@ public class NotificationService {
         } catch (IllegalArgumentException e) {
             throw new CustomException(ErrorCode.COMMON_BAD_REQUEST, "유효하지 않은 알림 타입입니다.");
         }
-    }
-
-    @Transactional
-    public void markAllAsRead(Long memberId) {
-        notificationRepository.markAllAsReadByMemberId(memberId);
     }
 }

--- a/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
@@ -22,9 +22,8 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     @Transactional(readOnly = true)
-    public NotificationListResponse getNotifications(Long memberId, String typeParam, String cursor) {
+    public NotificationListResponse getNotifications(Long memberId, NotificationType type, String cursor) {
         Long cursorId = parseCursor(cursor);
-        NotificationType type = parseType(typeParam);
         int fetchSize = DEFAULT_LIMIT + 1;
 
         List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
@@ -70,14 +69,4 @@ public class NotificationService {
         }
     }
 
-    private NotificationType parseType(String type) {
-        if (type == null || type.isBlank()) {
-            return null;
-        }
-        try {
-            return NotificationType.valueOf(type.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.COMMON_BAD_REQUEST, "유효하지 않은 알림 타입입니다.");
-        }
-    }
 }

--- a/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/doori/doori_backend/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.doori.doori_backend.notification.service;
 import com.doori.doori_backend.global.error.ErrorCode;
 import com.doori.doori_backend.global.exception.CustomException;
 import com.doori.doori_backend.notification.domain.Notification;
+import com.doori.doori_backend.notification.domain.NotificationType;
 import com.doori.doori_backend.notification.dto.response.NotificationItem;
 import com.doori.doori_backend.notification.dto.response.NotificationListResponse;
 import com.doori.doori_backend.notification.repository.NotificationRepository;
@@ -21,12 +22,13 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     @Transactional(readOnly = true)
-    public NotificationListResponse getNotifications(Long memberId, String cursor) {
+    public NotificationListResponse getNotifications(Long memberId, String typeParam, String cursor) {
         Long cursorId = parseCursor(cursor);
+        NotificationType type = parseType(typeParam);
         int fetchSize = DEFAULT_LIMIT + 1;
 
         List<Notification> notifications = notificationRepository.findByReceiverWithCursor(
-            memberId, cursorId, PageRequest.of(0, fetchSize));
+            memberId, cursorId, type, PageRequest.of(0, fetchSize));
 
         boolean hasMore = notifications.size() == fetchSize;
         if (hasMore) {
@@ -60,6 +62,17 @@ public class NotificationService {
             return Long.parseLong(cursor);
         } catch (NumberFormatException e) {
             throw new CustomException(ErrorCode.COMMON_BAD_REQUEST, "유효하지 않은 커서 값입니다.");
+        }
+    }
+
+    private NotificationType parseType(String type) {
+        if (type == null || type.isBlank()) {
+            return null;
+        }
+        try {
+            return NotificationType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.COMMON_BAD_REQUEST, "유효하지 않은 알림 타입입니다.");
         }
     }
 

--- a/src/main/java/com/doori/doori_backend/user/controller/UserController.java
+++ b/src/main/java/com/doori/doori_backend/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.doori.doori_backend.user.dto.request.DeleteAccountRequest;
 import com.doori.doori_backend.user.dto.request.UpdateProfileRequest;
 import com.doori.doori_backend.user.dto.response.ExploreResponse;
 import com.doori.doori_backend.user.dto.response.MyProfileResponse;
+import com.doori.doori_backend.user.dto.response.ProfileCardResponse;
 import com.doori.doori_backend.user.dto.response.RecommendationsResponse;
 import com.doori.doori_backend.user.dto.response.UserProfileResponse;
 import com.doori.doori_backend.user.service.UserDiscoveryService;
@@ -75,6 +76,15 @@ public class UserController {
         return ResponseEntity.ok(
             ApiResponse.success(userDiscoveryService.explore(memberId, residenceType, isSmoker, cursor, limit))
         );
+    }
+
+    @GetMapping("/{userId}/card")
+    public ResponseEntity<ApiResponse<ProfileCardResponse>> getProfileCard(
+        @PathVariable Long userId,
+        Authentication authentication
+    ) {
+        Long requesterId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(userDiscoveryService.getProfileCard(requesterId, userId)));
     }
 
     @DeleteMapping("/me")

--- a/src/main/java/com/doori/doori_backend/user/controller/UserController.java
+++ b/src/main/java/com/doori/doori_backend/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.doori.doori_backend.user.dto.response.MyProfileResponse;
 import com.doori.doori_backend.user.dto.response.ProfileCardResponse;
 import com.doori.doori_backend.user.dto.response.RecommendationsResponse;
 import com.doori.doori_backend.user.dto.response.UserProfileResponse;
+import com.doori.doori_backend.lifestyle.domain.HousingType;
 import com.doori.doori_backend.user.service.UserDiscoveryService;
 import com.doori.doori_backend.user.service.UserProfileService;
 import jakarta.validation.Valid;
@@ -66,7 +67,7 @@ public class UserController {
 
     @GetMapping("/explore")
     public ResponseEntity<ApiResponse<ExploreResponse>> explore(
-        @RequestParam(required = false) String residenceType,
+        @RequestParam(required = false) HousingType residenceType,
         @RequestParam(required = false) Boolean isSmoker,
         @RequestParam(required = false) String cursor,
         @RequestParam(defaultValue = "20") int limit,

--- a/src/main/java/com/doori/doori_backend/user/dto/response/ProfileCardResponse.java
+++ b/src/main/java/com/doori/doori_backend/user/dto/response/ProfileCardResponse.java
@@ -1,0 +1,32 @@
+package com.doori.doori_backend.user.dto.response;
+
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
+import java.util.List;
+
+public record ProfileCardResponse(
+    Long userId,
+    String name,
+    String nickname,
+    String gender,
+    String schoolName,
+    String profileImageUrl,
+    String bio,
+    int matchingScore,
+    List<String> matchedCriteria
+) {
+    public static ProfileCardResponse of(Member member, LifestyleProfile profile,
+        int matchingScore, List<String> matchedCriteria) {
+        return new ProfileCardResponse(
+            member.getId(),
+            member.getName(),
+            member.getNickname(),
+            member.getGender().name(),
+            member.getSchool().getDisplayName(),
+            member.getProfileImageUrl(),
+            profile != null ? profile.getBio() : null,
+            matchingScore,
+            matchedCriteria
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/user/service/MatchingScoreCalculator.java
+++ b/src/main/java/com/doori/doori_backend/user/service/MatchingScoreCalculator.java
@@ -1,25 +1,69 @@
 package com.doori.doori_backend.user.service;
 
 import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
+/**
+ * 매칭 스코어 계산기.
+ *
+ * 현재 배점은 임시값이며, 회의 후 확정할 예정입니다.
+ * 각 항목별 배점 근거:
+ *   - isSmoker (20pt): 흡연 여부는 동거 적합성에 크게 영향을 미침
+ *   - sleepTime (15pt): 취침 패턴 일치는 생활 리듬 호환성의 핵심
+ *   - wakeUpTime (10pt): 기상 패턴 일치
+ *   - cleaningCycle (15pt): 청소 주기 일치
+ *   - cleanlinessLevel (15pt): ImportanceLevel.score 차이가 작을수록 높은 점수
+ *   - noiseSensitivity (15pt): ImportanceLevel.score 차이가 작을수록 높은 점수
+ *   - atmosphere (10pt): 생활 분위기 일치
+ * 합계: 100pt
+ */
 @Component
 public class MatchingScoreCalculator {
 
     public int calculate(LifestyleProfile a, LifestyleProfile b) {
         int score = 0;
-        if (a.getHousingType() != null && a.getHousingType().equals(b.getHousingType())) {
-            score += 30;
-        }
-        if (a.getPreferredRegion() != null && a.getPreferredRegion().equals(b.getPreferredRegion())) {
-            score += 30;
-        }
+
         if (a.getIsSmoker() != null && a.getIsSmoker().equals(b.getIsSmoker())) {
             score += 20;
         }
-        if (a.getMember().getSchool().equals(b.getMember().getSchool())) {
-            score += 20;
+        if (a.getSleepTime() != null && a.getSleepTime().equals(b.getSleepTime())) {
+            score += 15;
         }
+        if (a.getWakeUpTime() != null && a.getWakeUpTime().equals(b.getWakeUpTime())) {
+            score += 10;
+        }
+        if (a.getCleaningCycle() != null && a.getCleaningCycle().equals(b.getCleaningCycle())) {
+            score += 15;
+        }
+        if (a.getCleanlinessLevel() != null && b.getCleanlinessLevel() != null) {
+            score += scoreByProximity(a.getCleanlinessLevel().getScore(), b.getCleanlinessLevel().getScore(), 15);
+        }
+        if (a.getNoiseSensitivity() != null && b.getNoiseSensitivity() != null) {
+            score += scoreByProximity(a.getNoiseSensitivity().getScore(), b.getNoiseSensitivity().getScore(), 15);
+        }
+        if (a.getAtmosphere() != null && a.getAtmosphere().equals(b.getAtmosphere())) {
+            score += 10;
+        }
+
         return score;
+    }
+
+    public List<String> matchedCriteria(LifestyleProfile a, LifestyleProfile b) {
+        List<String> matched = new ArrayList<>();
+        if (a.getIsSmoker() != null && a.getIsSmoker().equals(b.getIsSmoker())) matched.add("SMOKING");
+        if (a.getSleepTime() != null && a.getSleepTime().equals(b.getSleepTime())) matched.add("SLEEP_TIME");
+        if (a.getWakeUpTime() != null && a.getWakeUpTime().equals(b.getWakeUpTime())) matched.add("WAKE_UP_TIME");
+        if (a.getCleaningCycle() != null && a.getCleaningCycle().equals(b.getCleaningCycle())) matched.add("CLEANING_CYCLE");
+        if (a.getAtmosphere() != null && a.getAtmosphere().equals(b.getAtmosphere())) matched.add("ATMOSPHERE");
+        return matched;
+    }
+
+    private int scoreByProximity(int scoreA, int scoreB, int maxPts) {
+        int diff = Math.abs(scoreA - scoreB);
+        if (diff == 0) return maxPts;
+        if (diff == 2) return maxPts / 2;
+        return 0;
     }
 }

--- a/src/main/java/com/doori/doori_backend/user/service/MatchingScoreCalculator.java
+++ b/src/main/java/com/doori/doori_backend/user/service/MatchingScoreCalculator.java
@@ -52,11 +52,31 @@ public class MatchingScoreCalculator {
 
     public List<String> matchedCriteria(LifestyleProfile a, LifestyleProfile b) {
         List<String> matched = new ArrayList<>();
-        if (a.getIsSmoker() != null && a.getIsSmoker().equals(b.getIsSmoker())) matched.add("SMOKING");
-        if (a.getSleepTime() != null && a.getSleepTime().equals(b.getSleepTime())) matched.add("SLEEP_TIME");
-        if (a.getWakeUpTime() != null && a.getWakeUpTime().equals(b.getWakeUpTime())) matched.add("WAKE_UP_TIME");
-        if (a.getCleaningCycle() != null && a.getCleaningCycle().equals(b.getCleaningCycle())) matched.add("CLEANING_CYCLE");
-        if (a.getAtmosphere() != null && a.getAtmosphere().equals(b.getAtmosphere())) matched.add("ATMOSPHERE");
+
+        if (a.getIsSmoker() != null && a.getIsSmoker().equals(b.getIsSmoker())) {
+            matched.add("SMOKING");
+        }
+        if (a.getSleepTime() != null && a.getSleepTime().equals(b.getSleepTime())) {
+            matched.add("SLEEP_TIME");
+        }
+        if (a.getWakeUpTime() != null && a.getWakeUpTime().equals(b.getWakeUpTime())) {
+            matched.add("WAKE_UP_TIME");
+        }
+        if (a.getCleaningCycle() != null && a.getCleaningCycle().equals(b.getCleaningCycle())) {
+            matched.add("CLEANING_CYCLE");
+        }
+        if (a.getCleanlinessLevel() != null && b.getCleanlinessLevel() != null
+            && a.getCleanlinessLevel() == b.getCleanlinessLevel()) {
+            matched.add("CLEANLINESS_LEVEL");
+        }
+        if (a.getNoiseSensitivity() != null && b.getNoiseSensitivity() != null
+            && a.getNoiseSensitivity() == b.getNoiseSensitivity()) {
+            matched.add("NOISE_SENSITIVITY");
+        }
+        if (a.getAtmosphere() != null && a.getAtmosphere().equals(b.getAtmosphere())) {
+            matched.add("ATMOSPHERE");
+        }
+
         return matched;
     }
 

--- a/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
+++ b/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
@@ -10,6 +10,7 @@ import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
 import com.doori.doori_backend.lifestyle.repository.LifestyleProfileRepository;
 import com.doori.doori_backend.user.dto.response.ExploreItem;
 import com.doori.doori_backend.user.dto.response.ExploreResponse;
+import com.doori.doori_backend.user.dto.response.ProfileCardResponse;
 import com.doori.doori_backend.user.dto.response.RecommendationsResponse;
 import com.doori.doori_backend.user.dto.response.UserProfileResponse;
 import java.nio.charset.StandardCharsets;
@@ -98,6 +99,25 @@ public class UserDiscoveryService {
 
         String nextCursor = hasMore ? encodeCursor(page.get(page.size() - 1).getMember().getId()) : null;
         return new ExploreResponse(items, nextCursor, hasMore);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileCardResponse getProfileCard(Long requesterId, Long targetId) {
+        Member target = memberRepository.findById(targetId)
+            .filter(m -> m.getStatus() == MemberStatus.ACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Optional<LifestyleProfile> requesterProfile = lifestyleProfileRepository.findByMemberId(requesterId);
+        Optional<LifestyleProfile> targetProfile = lifestyleProfileRepository.findByMemberId(targetId);
+
+        int matchingScore = 0;
+        List<String> matched = List.of();
+        if (requesterProfile.isPresent() && targetProfile.isPresent()) {
+            matchingScore = scoreCalculator.calculate(requesterProfile.get(), targetProfile.get());
+            matched = scoreCalculator.matchedCriteria(requesterProfile.get(), targetProfile.get());
+        }
+
+        return ProfileCardResponse.of(target, targetProfile.orElse(null), matchingScore, matched);
     }
 
     private int computeMatchingScore(Long requesterId, Long targetId) {

--- a/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
+++ b/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
@@ -77,7 +77,7 @@ public class UserDiscoveryService {
         long cursorId = decodeCursor(cursor);
 
         List<LifestyleProfile> results = lifestyleProfileRepository.findForExplore(
-            MemberStatus.ACTIVE, housingType, isSmoker, cursorId,
+            MemberStatus.ACTIVE, memberId, housingType, isSmoker, cursorId,
             PageRequest.of(0, limit + 1)
         );
 
@@ -89,7 +89,6 @@ public class UserDiscoveryService {
         );
 
         List<ExploreItem> items = page.stream()
-            .filter(p -> !p.getMember().getId().equals(memberId))
             .map(profile -> ExploreItem.of(
                 profile.getMember(), profile,
                 myProfile.map(mp -> scoreCalculator.calculate(mp, profile)).orElse(0),

--- a/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
+++ b/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
@@ -68,12 +68,11 @@ public class UserDiscoveryService {
     @Transactional(readOnly = true)
     public ExploreResponse explore(
         Long memberId,
-        String residenceType,
+        HousingType housingType,
         Boolean isSmoker,
         String cursor,
         int limit
     ) {
-        HousingType housingType = parseHousingType(residenceType);
         long cursorId = decodeCursor(cursor);
 
         List<LifestyleProfile> results = lifestyleProfileRepository.findForExplore(
@@ -133,17 +132,6 @@ public class UserDiscoveryService {
         return memberRepository.findById(memberId)
             .filter(m -> m.getStatus() == MemberStatus.ACTIVE)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private HousingType parseHousingType(String residenceType) {
-        if (residenceType == null || residenceType.isBlank()) {
-            return null;
-        }
-        try {
-            return HousingType.fromValue(residenceType);
-        } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.COMMON_BAD_REQUEST);
-        }
     }
 
     private long decodeCursor(String cursor) {


### PR DESCRIPTION
## 연관 이슈

Closes #32

## 변경 요약

- 디자인 온보딩 화면 기준으로 `LifestyleProfile` 필드 추가
- 알림 유형(`NotificationType`) 디자인 탭과 정합성 맞춤
- 프로필 카드 전용 API 엔드포인트 신설
- 매칭 스코어 계산 로직 신규 필드 반영

## 구현 상세

### 1. 신규 Enum (lifestyle/domain/)

| Enum | 값 | 온보딩 화면 |
|---|---|---|
| `SleepTime` | EARLY / LATE / IRREGULAR | 온보딩 19 — 보통 언제 잠에 드나요? |
| `WakeUpTime` | EARLY / LATE / IRREGULAR | 온보딩 미포함 → 추가 필요 확인 |
| `CleaningCycle` | DAILY / WEEKLY / MONTHLY / OTHER | 온보딩 미포함 → 추가 필요 확인 |
| `ImportanceLevel` | VERY_IMPORTANT(5) / NORMAL(3) / NOT_CARE(1) | 청결도·소음 민감도 공용 |
| `Atmosphere` | QUIET / MODERATE / SOCIAL | 온보딩 21 — 어떤 분위기의 생활? |
| `PriorityCriteria` | SLEEP_PATTERN / CLEANLINESS / SMOKING / NOISE / PERSONALITY | 온보딩 21 — 가장 중요한 기준 1가지 |

### 2. LifestyleProfile 필드 추가

```
sleepTime       : SleepTime
wakeUpTime      : WakeUpTime
cleaningCycle   : CleaningCycle
cleanlinessLevel: ImportanceLevel  // 청결도 중요도
noiseSensitivity: ImportanceLevel  // 소음 민감도
atmosphere      : Atmosphere
priorityCriteria: PriorityCriteria
bio             : String (200자)   // 자기소개
roommateWish    : String (200자)   // 룸메 희망 사항
```

`isComplete()` 조건: `housingType`, `isSmoker`, `sleepTime`, `wakeUpTime`, `cleaningCycle`, `cleanlinessLevel`, `noiseSensitivity`, `atmosphere` 전부 non-null

### 3. NotificationType 변경

| 기존 | 변경 후 | 설명 |
|---|---|---|
| MATCH | MATCH_REQUEST | 매칭 요청 알림 |
| — | MATCH_RESULT | 매칭 결과 알림 |
| CHAT | CHAT (유지) | 채팅 탭 알림 |
| — | LIFESTYLE_RULE | 생활 규칙 알림 (**트리거 로직 미구현 — 타입 예약**) |
| COMMUNITY | COMMUNITY_COMMENT | 커뮤니티 댓글 알림 |
| SYSTEM | SYSTEM (유지) | 시스템 알림 |

> ⚠️ **LIFESTYLE_RULE 주의사항**: 룸메와 생활 규칙을 설정/변경할 때 발송되는 알림으로 기획됐으나,
> 현재 생활 규칙 동의 기능 자체가 미구현 상태입니다. Enum 타입만 선점해두고 실제 발송 로직은 해당 기능 구현 시 추가 예정.

### 4. 알림 타입 필터

`GET /api/notifications?type=MATCH_REQUEST&cursor=...`

`type` 파라미터를 생략하면 전체 조회 (기존 동작 유지).

### 5. 프로필 카드 API (신규)

`GET /api/users/{userId}/card`

```json
{
  "userId": 1,
  "name": "홍길동",
  "nickname": "gildong",
  "gender": "M",
  "schoolName": "한양대학교",
  "profileImageUrl": "...",
  "bio": "자기소개 텍스트",
  "matchingScore": 75,
  "matchedCriteria": ["SMOKING", "SLEEP_TIME", "ATMOSPHERE"]
}
```

- `matchedCriteria`: 요청자와 대상자 간 일치하는 생활 성향 항목 목록
- `matchingScore`: 0~100 점 (신규 배점 기준 적용)

### 6. MatchingScoreCalculator 배점 (임시값 — 회의 후 확정 필요)

| 항목 | 배점 | 비고 |
|---|---|---|
| 흡연 여부 (isSmoker) | 20pt | 일치 시 |
| 취침 시간 (sleepTime) | 15pt | 일치 시 |
| 기상 시간 (wakeUpTime) | 10pt | 일치 시 |
| 청소 주기 (cleaningCycle) | 15pt | 일치 시 |
| 청결 중요도 (cleanlinessLevel) | 15pt | score 차 0→15pt, 차 2→7pt, 차 4→0pt |
| 소음 민감도 (noiseSensitivity) | 15pt | 동일 방식 |
| 생활 분위기 (atmosphere) | 10pt | 일치 시 |
| **합계** | **100pt** | |

> ⚠️ **임시 배점**: ImportanceLevel score값(1/3/5) 기반 근접도 계산이며, 실제 가중치는 팀 회의 후 조정 예정.

## 테스트 결과

```
./gradlew clean build → BUILD SUCCESSFUL
```

## 체크리스트

- [x] 변경 파일이 이번 작업 범위에 정확히 맞는다.
- [x] 테스트를 실행했다. (`./gradlew clean build`)
- [x] PR 본문에 `Closes #32` 포함
- [x] 임시값 항목은 PR 본문에 명시해두었다.