### PR TITLE
[✨ Feat] chat 도메인 분리 및 NotificationType CHAT 제거 (#34)

### DIFF
--- a/src/main/java/com/doori/doori_backend/chat/domain/ChatMessage.java
+++ b/src/main/java/com/doori/doori_backend/chat/domain/ChatMessage.java
@@ -1,0 +1,61 @@
+package com.doori.doori_backend.chat.domain;
+
+import com.doori.doori_backend.user.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MessageType messageType;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime sentAt;
+
+    @Builder
+    public ChatMessage(ChatRoom chatRoom, Member sender, String content, MessageType messageType) {
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+        this.content = content;
+        this.messageType = messageType;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/doori/doori_backend/chat/domain/ChatParticipant.java
@@ -1,0 +1,56 @@
+package com.doori.doori_backend.chat.domain;
+
+import com.doori.doori_backend.user.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "chat_participant")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChatParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime joinedAt;
+
+    private LocalDateTime lastReadAt;
+
+    public static ChatParticipant of(ChatRoom chatRoom, Member member) {
+        ChatParticipant participant = new ChatParticipant();
+        participant.chatRoom = chatRoom;
+        participant.member = member;
+        return participant;
+    }
+
+    public void updateLastReadAt(LocalDateTime readAt) {
+        this.lastReadAt = readAt;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/chat/domain/ChatRoom.java
+++ b/src/main/java/com/doori/doori_backend/chat/domain/ChatRoom.java
@@ -1,0 +1,48 @@
+package com.doori.doori_backend.chat.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "chat_room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatParticipant> participants = new ArrayList<>();
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastMessageAt;
+
+    public static ChatRoom create() {
+        return new ChatRoom();
+    }
+
+    public void updateLastMessageAt(LocalDateTime sentAt) {
+        this.lastMessageAt = sentAt;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/chat/domain/MessageType.java
+++ b/src/main/java/com/doori/doori_backend/chat/domain/MessageType.java
@@ -1,0 +1,6 @@
+package com.doori.doori_backend.chat.domain;
+
+public enum MessageType {
+    TEXT,
+    IMAGE
+}

--- a/src/main/java/com/doori/doori_backend/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/doori/doori_backend/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.chat.repository;
+
+import com.doori.doori_backend.chat.domain.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/doori/doori_backend/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/doori/doori_backend/chat/repository/ChatParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.chat.repository;
+
+import com.doori.doori_backend.chat.domain.ChatParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+}

--- a/src/main/java/com/doori/doori_backend/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/doori/doori_backend/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.chat.repository;
+
+import com.doori.doori_backend.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/doori/doori_backend/notification/domain/NotificationType.java
+++ b/src/main/java/com/doori/doori_backend/notification/domain/NotificationType.java
@@ -2,7 +2,6 @@ package com.doori.doori_backend.notification.domain;
 
 public enum NotificationType {
     MATCH,
-    CHAT,
     COMMUNITY,
     SYSTEM
 }


### PR DESCRIPTION
## 연관 이슈

Closes #34

## 변경 요약

- `NotificationType`에서 `CHAT` 제거 → SSE 기반 알림 타입만 유지
- `chat` 도메인 패키지 신규 생성 (WebSocket/Supabase 구현 전 도메인 분리)

## 구현 상세

### notification 도메인 변경
- `NotificationType.CHAT` 제거
- 잔여 타입: `MATCH`, `COMMUNITY`, `SYSTEM`

### chat 도메인 신규 생성
| 파일 | 설명 |
|---|---|
| `ChatRoom` | 채팅방 엔티티 (participants, lastMessageAt) |
| `ChatParticipant` | 채팅방 참여자 (Member ↔ ChatRoom, lastReadAt) |
| `ChatMessage` | 채팅 메시지 (content, MessageType, sentAt) |
| `MessageType` | `TEXT`, `IMAGE` |
| `ChatRoom/Participant/MessageRepository` | JpaRepository 기본 인터페이스 |

> 채팅 서비스/컨트롤러는 WebSocket 또는 Supabase 방식 확정 후 별도 이슈로 구현 예정

## 테스트 결과

- `./gradlew clean build` 통과

## 체크리스트

- [x] 변경 파일이 이번 작업 범위에 맞는다
- [x] 빌드 성공 확인
- [x] PR 범위를 벗어난 변경 없음