### PR TITLE
[✨ Feat] 생활 성향 API 구현 및 LifestyleProfile 필드 확장 (#39)

### DIFF
--- a/src/main/java/com/doori/doori_backend/lifestyle/controller/LifestyleController.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/controller/LifestyleController.java
@@ -1,0 +1,39 @@
+package com.doori.doori_backend.lifestyle.controller;
+
+import com.doori.doori_backend.global.response.ApiResponse;
+import com.doori.doori_backend.lifestyle.dto.request.LifestyleUpdateRequest;
+import com.doori.doori_backend.lifestyle.dto.response.LifestyleProfileResponse;
+import com.doori.doori_backend.lifestyle.service.LifestyleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/lifestyle")
+@RequiredArgsConstructor
+public class LifestyleController {
+
+    private final LifestyleService lifestyleService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<LifestyleProfileResponse>> getMyLifestyle(Authentication authentication) {
+        Long memberId = (Long) authentication.getPrincipal();
+        return ResponseEntity.ok(ApiResponse.success(lifestyleService.getMyLifestyle(memberId)));
+    }
+
+    @PutMapping("/edit")
+    public ResponseEntity<Void> updateLifestyle(
+        @RequestBody @Valid LifestyleUpdateRequest request,
+        Authentication authentication
+    ) {
+        Long memberId = (Long) authentication.getPrincipal();
+        lifestyleService.updateLifestyle(memberId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/Atmosphere.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/Atmosphere.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum Atmosphere {
+    QUIET,
+    MODERATE,
+    SOCIAL
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/CleaningCycle.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/CleaningCycle.java
@@ -1,0 +1,8 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum CleaningCycle {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    OTHER
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/ImportanceLevel.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/ImportanceLevel.java
@@ -1,0 +1,17 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum ImportanceLevel {
+    VERY_IMPORTANT(5),
+    NORMAL(3),
+    NOT_CARE(1);
+
+    private final int score;
+
+    ImportanceLevel(int score) {
+        this.score = score;
+    }
+
+    public int getScore() {
+        return score;
+    }
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/LifestyleProfile.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/LifestyleProfile.java
@@ -38,6 +38,33 @@ public class LifestyleProfile {
 
     private Boolean isSmoker;
 
+    @Enumerated(EnumType.STRING)
+    private SleepTime sleepTime;
+
+    @Enumerated(EnumType.STRING)
+    private WakeUpTime wakeUpTime;
+
+    @Enumerated(EnumType.STRING)
+    private CleaningCycle cleaningCycle;
+
+    @Enumerated(EnumType.STRING)
+    private ImportanceLevel cleanlinessLevel;
+
+    @Enumerated(EnumType.STRING)
+    private ImportanceLevel noiseSensitivity;
+
+    @Enumerated(EnumType.STRING)
+    private Atmosphere atmosphere;
+
+    @Enumerated(EnumType.STRING)
+    private PriorityCriteria priorityCriteria;
+
+    @Column(length = 200)
+    private String bio;
+
+    @Column(length = 200)
+    private String roommateWish;
+
     @Builder
     public LifestyleProfile(Member member, HousingType housingType, String preferredRegion, Boolean isSmoker) {
         this.member = member;
@@ -46,7 +73,42 @@ public class LifestyleProfile {
         this.isSmoker = isSmoker;
     }
 
+    public void update(
+        HousingType housingType,
+        String preferredRegion,
+        Boolean isSmoker,
+        SleepTime sleepTime,
+        WakeUpTime wakeUpTime,
+        CleaningCycle cleaningCycle,
+        ImportanceLevel cleanlinessLevel,
+        ImportanceLevel noiseSensitivity,
+        Atmosphere atmosphere,
+        PriorityCriteria priorityCriteria,
+        String bio,
+        String roommateWish
+    ) {
+        this.housingType = housingType;
+        this.preferredRegion = preferredRegion;
+        this.isSmoker = isSmoker;
+        this.sleepTime = sleepTime;
+        this.wakeUpTime = wakeUpTime;
+        this.cleaningCycle = cleaningCycle;
+        this.cleanlinessLevel = cleanlinessLevel;
+        this.noiseSensitivity = noiseSensitivity;
+        this.atmosphere = atmosphere;
+        this.priorityCriteria = priorityCriteria;
+        this.bio = bio;
+        this.roommateWish = roommateWish;
+    }
+
     public boolean isComplete() {
-        return housingType != null && preferredRegion != null;
+        return housingType != null
+            && isSmoker != null
+            && sleepTime != null
+            && wakeUpTime != null
+            && cleaningCycle != null
+            && cleanlinessLevel != null
+            && noiseSensitivity != null
+            && atmosphere != null;
     }
 }

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/PriorityCriteria.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/PriorityCriteria.java
@@ -1,0 +1,9 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum PriorityCriteria {
+    SLEEP_PATTERN,
+    CLEANLINESS,
+    SMOKING,
+    NOISE,
+    PERSONALITY
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/SleepTime.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/SleepTime.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum SleepTime {
+    EARLY,
+    LATE,
+    IRREGULAR
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/domain/WakeUpTime.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/domain/WakeUpTime.java
@@ -1,0 +1,7 @@
+package com.doori.doori_backend.lifestyle.domain;
+
+public enum WakeUpTime {
+    EARLY,
+    LATE,
+    IRREGULAR
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/dto/request/LifestyleUpdateRequest.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/dto/request/LifestyleUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.doori.doori_backend.lifestyle.dto.request;
+
+import com.doori.doori_backend.lifestyle.domain.Atmosphere;
+import com.doori.doori_backend.lifestyle.domain.CleaningCycle;
+import com.doori.doori_backend.lifestyle.domain.HousingType;
+import com.doori.doori_backend.lifestyle.domain.ImportanceLevel;
+import com.doori.doori_backend.lifestyle.domain.PriorityCriteria;
+import com.doori.doori_backend.lifestyle.domain.SleepTime;
+import com.doori.doori_backend.lifestyle.domain.WakeUpTime;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LifestyleUpdateRequest(
+    @NotNull HousingType housingType,
+    String preferredRegion,
+    @NotNull Boolean isSmoker,
+    @NotNull SleepTime sleepTime,
+    @NotNull WakeUpTime wakeUpTime,
+    @NotNull CleaningCycle cleaningCycle,
+    @NotNull ImportanceLevel cleanlinessLevel,
+    @NotNull ImportanceLevel noiseSensitivity,
+    @NotNull Atmosphere atmosphere,
+    PriorityCriteria priorityCriteria,
+    @Size(max = 200) String bio,
+    @Size(max = 200) String roommateWish
+) {}

--- a/src/main/java/com/doori/doori_backend/lifestyle/dto/response/LifestyleProfileResponse.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/dto/response/LifestyleProfileResponse.java
@@ -1,0 +1,44 @@
+package com.doori.doori_backend.lifestyle.dto.response;
+
+import com.doori.doori_backend.lifestyle.domain.Atmosphere;
+import com.doori.doori_backend.lifestyle.domain.CleaningCycle;
+import com.doori.doori_backend.lifestyle.domain.HousingType;
+import com.doori.doori_backend.lifestyle.domain.ImportanceLevel;
+import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
+import com.doori.doori_backend.lifestyle.domain.PriorityCriteria;
+import com.doori.doori_backend.lifestyle.domain.SleepTime;
+import com.doori.doori_backend.lifestyle.domain.WakeUpTime;
+
+public record LifestyleProfileResponse(
+    String housingType,
+    String preferredRegion,
+    Boolean isSmoker,
+    SleepTime sleepTime,
+    WakeUpTime wakeUpTime,
+    CleaningCycle cleaningCycle,
+    ImportanceLevel cleanlinessLevel,
+    ImportanceLevel noiseSensitivity,
+    Atmosphere atmosphere,
+    PriorityCriteria priorityCriteria,
+    String bio,
+    String roommateWish,
+    boolean isComplete
+) {
+    public static LifestyleProfileResponse from(LifestyleProfile profile) {
+        return new LifestyleProfileResponse(
+            profile.getHousingType() != null ? profile.getHousingType().getValue() : null,
+            profile.getPreferredRegion(),
+            profile.getIsSmoker(),
+            profile.getSleepTime(),
+            profile.getWakeUpTime(),
+            profile.getCleaningCycle(),
+            profile.getCleanlinessLevel(),
+            profile.getNoiseSensitivity(),
+            profile.getAtmosphere(),
+            profile.getPriorityCriteria(),
+            profile.getBio(),
+            profile.getRoommateWish(),
+            profile.isComplete()
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/lifestyle/repository/LifestyleProfileRepository.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/repository/LifestyleProfileRepository.java
@@ -1,9 +1,10 @@
 package com.doori.doori_backend.lifestyle.repository;
 
-import com.doori.doori_backend.user.domain.Member;
-import com.doori.doori_backend.user.domain.MemberStatus;
 import com.doori.doori_backend.lifestyle.domain.HousingType;
 import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
+import com.doori.doori_backend.school.domain.School;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -20,10 +21,12 @@ public interface LifestyleProfileRepository extends JpaRepository<LifestyleProfi
     @Query("""
         SELECT lp FROM LifestyleProfile lp
         WHERE lp.member.status = :status
+          AND lp.member.school = :school
           AND lp.member.id != :excludeMemberId
         """)
     List<LifestyleProfile> findActiveExcluding(
         @Param("status") MemberStatus status,
+        @Param("school") School school,
         @Param("excludeMemberId") Long excludeMemberId,
         Pageable pageable
     );
@@ -31,6 +34,7 @@ public interface LifestyleProfileRepository extends JpaRepository<LifestyleProfi
     @Query("""
         SELECT lp FROM LifestyleProfile lp
         WHERE lp.member.status = :status
+          AND lp.member.school = :school
           AND (:housingType IS NULL OR lp.housingType = :housingType)
           AND (:isSmoker IS NULL OR lp.isSmoker = :isSmoker)
           AND lp.member.id > :cursorId
@@ -38,6 +42,7 @@ public interface LifestyleProfileRepository extends JpaRepository<LifestyleProfi
         """)
     List<LifestyleProfile> findForExplore(
         @Param("status") MemberStatus status,
+        @Param("school") School school,
         @Param("housingType") HousingType housingType,
         @Param("isSmoker") Boolean isSmoker,
         @Param("cursorId") Long cursorId,

--- a/src/main/java/com/doori/doori_backend/lifestyle/service/LifestyleService.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/service/LifestyleService.java
@@ -22,7 +22,10 @@ public class LifestyleService {
 
     @Transactional(readOnly = true)
     public LifestyleProfileResponse getMyLifestyle(Long memberId) {
-        LifestyleProfile profile = lifestyleProfileRepository.findByMemberId(memberId)
+        Member member = memberRepository.findById(memberId)
+            .filter(m -> m.getStatus() == MemberStatus.ACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        LifestyleProfile profile = lifestyleProfileRepository.findByMember(member)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_LIFESTYLE_PROFILE_REQUIRED));
         return LifestyleProfileResponse.from(profile);
     }

--- a/src/main/java/com/doori/doori_backend/lifestyle/service/LifestyleService.java
+++ b/src/main/java/com/doori/doori_backend/lifestyle/service/LifestyleService.java
@@ -1,0 +1,56 @@
+package com.doori.doori_backend.lifestyle.service;
+
+import com.doori.doori_backend.global.error.ErrorCode;
+import com.doori.doori_backend.global.exception.CustomException;
+import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
+import com.doori.doori_backend.lifestyle.dto.request.LifestyleUpdateRequest;
+import com.doori.doori_backend.lifestyle.dto.response.LifestyleProfileResponse;
+import com.doori.doori_backend.lifestyle.repository.LifestyleProfileRepository;
+import com.doori.doori_backend.user.domain.Member;
+import com.doori.doori_backend.user.domain.MemberStatus;
+import com.doori.doori_backend.user.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LifestyleService {
+
+    private final LifestyleProfileRepository lifestyleProfileRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public LifestyleProfileResponse getMyLifestyle(Long memberId) {
+        LifestyleProfile profile = lifestyleProfileRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_LIFESTYLE_PROFILE_REQUIRED));
+        return LifestyleProfileResponse.from(profile);
+    }
+
+    @Transactional
+    public void updateLifestyle(Long memberId, LifestyleUpdateRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .filter(m -> m.getStatus() == MemberStatus.ACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LifestyleProfile profile = lifestyleProfileRepository.findByMember(member)
+            .orElseGet(() -> lifestyleProfileRepository.save(
+                LifestyleProfile.builder().member(member).build()
+            ));
+
+        profile.update(
+            request.housingType(),
+            request.preferredRegion(),
+            request.isSmoker(),
+            request.sleepTime(),
+            request.wakeUpTime(),
+            request.cleaningCycle(),
+            request.cleanlinessLevel(),
+            request.noiseSensitivity(),
+            request.atmosphere(),
+            request.priorityCriteria(),
+            request.bio(),
+            request.roommateWish()
+        );
+    }
+}

--- a/src/main/java/com/doori/doori_backend/user/service/MatchingScoreCalculator.java
+++ b/src/main/java/com/doori/doori_backend/user/service/MatchingScoreCalculator.java
@@ -1,5 +1,6 @@
 package com.doori.doori_backend.user.service;
 
+import com.doori.doori_backend.lifestyle.domain.ImportanceLevel;
 import com.doori.doori_backend.lifestyle.domain.LifestyleProfile;
 import org.springframework.stereotype.Component;
 
@@ -8,18 +9,35 @@ public class MatchingScoreCalculator {
 
     public int calculate(LifestyleProfile a, LifestyleProfile b) {
         int score = 0;
-        if (a.getHousingType() != null && a.getHousingType().equals(b.getHousingType())) {
-            score += 30;
-        }
-        if (a.getPreferredRegion() != null && a.getPreferredRegion().equals(b.getPreferredRegion())) {
-            score += 30;
-        }
+
         if (a.getIsSmoker() != null && a.getIsSmoker().equals(b.getIsSmoker())) {
             score += 20;
         }
-        if (a.getMember().getSchool().equals(b.getMember().getSchool())) {
-            score += 20;
+        if (a.getSleepTime() != null && a.getSleepTime().equals(b.getSleepTime())) {
+            score += 15;
         }
+        if (a.getWakeUpTime() != null && a.getWakeUpTime().equals(b.getWakeUpTime())) {
+            score += 10;
+        }
+        if (a.getCleaningCycle() != null && a.getCleaningCycle().equals(b.getCleaningCycle())) {
+            score += 15;
+        }
+        score += proximityScore(a.getCleanlinessLevel(), b.getCleanlinessLevel(), 15);
+        score += proximityScore(a.getNoiseSensitivity(), b.getNoiseSensitivity(), 15);
+        if (a.getAtmosphere() != null && a.getAtmosphere().equals(b.getAtmosphere())) {
+            score += 10;
+        }
+
         return score;
+    }
+
+    private int proximityScore(ImportanceLevel a, ImportanceLevel b, int maxPt) {
+        if (a == null || b == null) {
+            return 0;
+        }
+        int diff = Math.abs(a.getScore() - b.getScore());
+        if (diff == 0) return maxPt;
+        if (diff == 2) return maxPt / 2;
+        return 0;
     }
 }

--- a/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
+++ b/src/main/java/com/doori/doori_backend/user/service/UserDiscoveryService.java
@@ -50,7 +50,7 @@ public class UserDiscoveryService {
             .orElseThrow(() -> new CustomException(ErrorCode.USER_LIFESTYLE_PROFILE_REQUIRED));
 
         List<LifestyleProfile> candidates = lifestyleProfileRepository.findActiveExcluding(
-            MemberStatus.ACTIVE, memberId, PageRequest.of(0, 50)
+            MemberStatus.ACTIVE, member.getSchool(), memberId, PageRequest.of(0, 50)
         );
 
         List<ExploreItem> recommendations = candidates.stream()
@@ -72,20 +72,19 @@ public class UserDiscoveryService {
         String cursor,
         int limit
     ) {
+        Member member = findActiveMember(memberId);
         HousingType housingType = parseHousingType(residenceType);
         long cursorId = decodeCursor(cursor);
 
         List<LifestyleProfile> results = lifestyleProfileRepository.findForExplore(
-            MemberStatus.ACTIVE, housingType, isSmoker, cursorId,
+            MemberStatus.ACTIVE, member.getSchool(), housingType, isSmoker, cursorId,
             PageRequest.of(0, limit + 1)
         );
 
         boolean hasMore = results.size() > limit;
         List<LifestyleProfile> page = hasMore ? results.subList(0, limit) : results;
 
-        Optional<LifestyleProfile> myProfile = lifestyleProfileRepository.findByMember(
-            findActiveMember(memberId)
-        );
+        Optional<LifestyleProfile> myProfile = lifestyleProfileRepository.findByMember(member);
 
         List<ExploreItem> items = page.stream()
             .filter(p -> !p.getMember().getId().equals(memberId))


### PR DESCRIPTION
## 연관 이슈

Closes #39

## 변경 요약

- 디자인 API 명세 기준 누락된 생활 성향 API 신규 구현 (`GET /api/lifestyle`, `PUT /api/lifestyle/edit`)
- `LifestyleProfile` 온보딩 화면 기준 신규 필드 9개 추가
- 생활 성향 관련 Enum 6개 추가
- `MatchingScoreCalculator` 신규 생활 성향 필드 기반 배점 로직으로 교체 (합계 100pt)
- school 동일 여부를 매칭 스코어 항목에서 쿼리 필터 사전 조건으로 변경

## 구현 상세

### 신규 Enum (`lifestyle/domain/`)

| Enum | 값 |
|---|---|
| `SleepTime` | EARLY / LATE / IRREGULAR |
| `WakeUpTime` | EARLY / LATE / IRREGULAR |
| `CleaningCycle` | DAILY / WEEKLY / MONTHLY / OTHER |
| `ImportanceLevel` | VERY_IMPORTANT(5) / NORMAL(3) / NOT_CARE(1) |
| `Atmosphere` | QUIET / MODERATE / SOCIAL |
| `PriorityCriteria` | SLEEP_PATTERN / CLEANLINESS / SMOKING / NOISE / PERSONALITY |

### LifestyleProfile 신규 필드

| 필드 | 타입 |
|---|---|
| `sleepTime` | SleepTime |
| `wakeUpTime` | WakeUpTime |
| `cleaningCycle` | CleaningCycle |
| `cleanlinessLevel` | ImportanceLevel |
| `noiseSensitivity` | ImportanceLevel |
| `atmosphere` | Atmosphere |
| `priorityCriteria` | PriorityCriteria |
| `bio` | String (200자) |
| `roommateWish` | String (200자) |

`isComplete()` 조건: housingType, isSmoker, sleepTime, wakeUpTime, cleaningCycle, cleanlinessLevel, noiseSensitivity, atmosphere 전부 non-null

### API

- `GET /api/lifestyle` — 내 생활 성향 조회
- `PUT /api/lifestyle/edit` — 생활 성향 수정 (없으면 생성, 있으면 업데이트)

### MatchingScoreCalculator 배점

| 항목 | 배점 | 비고 |
|---|---|---|
| isSmoker | 20pt | 일치 시 |
| sleepTime | 15pt | 일치 시 |
| wakeUpTime | 10pt | 일치 시 |
| cleaningCycle | 15pt | 일치 시 |
| cleanlinessLevel | 15pt | score 차 0→15pt, 차 2→7pt, 차 4→0pt |
| noiseSensitivity | 15pt | 동일 방식 |
| atmosphere | 10pt | 일치 시 |
| **합계** | **100pt** | |

### school 처리 변경

- 기존: `scoreCalculator`에서 school 일치 시 20pt 가산
- 변경: `findActiveExcluding`, `findForExplore` 쿼리에 `lp.member.school = :school` 조건 추가 → 같은 학교 유저만 후보에 포함

## 테스트 결과

```
./gradlew clean build → BUILD SUCCESSFUL
```

## 체크리스트

- [x] 신규 Enum 6개 추가
- [x] LifestyleProfile 필드 확장 및 `update()` 메서드 추가
- [x] `isComplete()` 조건 강화
- [x] LifestyleController / LifestyleService / DTO 구현
- [x] MatchingScoreCalculator 배점 로직 교체
- [x] school 필터 사전 조건 적용 (Repository + Service)
- [x] `./gradlew clean build` 통과
- [x] Controller 반환 타입 규칙 준수 (`ResponseEntity<ApiResponse<T>>` / `ResponseEntity<Void>`)